### PR TITLE
Implementation memoization for useEffect

### DIFF
--- a/src/hook.js
+++ b/src/hook.js
@@ -1,0 +1,28 @@
+import { current, notify } from './interface.js';
+import { hookSymbol } from './symbols.js';
+
+class Hook {
+  constructor(id, el) {
+    this.id = id;
+    this.el = el;
+  }
+}
+
+function use(Hook, ...args) {
+  let id = notify();
+  let hooks = current[hookSymbol];
+  
+  let hook = hooks.get(id);
+  if(!hook) {
+    hook = new Hook(id, current, ...args);
+    hooks.set(id, hook);
+  }
+
+  return hook.update(...args);
+}
+
+function hook(Hook) {
+  return use.bind(null, Hook);
+}
+
+export { hook, Hook };

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -1,6 +1,6 @@
 export const phaseSymbol = Symbol.for('haunted.phase');
-export const stateSymbol = Symbol.for('haunted.state');
-export const memoValuesSymbol = Symbol.for('haunted.memoValues');
+export const hookSymbol = Symbol.for('haunted.hook');
 
 export const updateSymbol = Symbol.for('haunted.update');
 export const commitSymbol = Symbol.for('haunted.commit');
+export const effectsSymbol = Symbol.for('haunted.effects');

--- a/src/use-effect.js
+++ b/src/use-effect.js
@@ -1,12 +1,40 @@
-import { commitSymbol } from './symbols.js';
-import { current, notify } from './interface.js';
+import { effectsSymbol } from './symbols.js';
+import { hook, Hook } from './hook.js';
 
-function useEffect(callback) {
-  let id = notify();
-  if(!(commitSymbol in current)) {
-    current[commitSymbol] = new Map();
+function setEffects(el, cb) {
+  if(!(effectsSymbol in el)) {
+    el[effectsSymbol] = [];
   }
-  current[commitSymbol].set(id, callback);
+  el[effectsSymbol].push(cb);
 }
+
+const useEffect = hook(class extends Hook {
+  constructor(id, el) {
+    super(id, el);
+    this.caller = this.caller.bind(this);
+    this.values = [];
+    setEffects(el, this.caller);
+  }
+
+  update(callback, values) {
+    this.callback = callback;
+    this.lastValues = this.values;
+    this.values = values;
+  }
+
+  caller() {
+    if(this.values) {
+      if(this.hasChanged()) {
+        this.callback.call(this.el);
+      }
+    } else {
+      this.callback.call(this.el);
+    }
+  }
+
+  hasChanged() {
+    return this.values.some((value, i) => this.lastValues[i] !== value);
+  }
+});
 
 export { useEffect };

--- a/src/use-reducer.js
+++ b/src/use-reducer.js
@@ -1,19 +1,21 @@
-import { current } from './interface.js';
-import { makeState, setState } from './use-state.js';
+import { hook, Hook } from './hook.js';
 
-function makeUpdateState(element, map, id, reducer) {
-  const updater = function(action) {
-    const currentValue = map.get(id)[0];
-    const newValue = reducer(currentValue, action);
-    setState(map, id, [newValue, updater]);
-    element._update();
-  };
-  return updater;
-}
+const useReducer = hook(class extends Hook {
+  constructor(id, el, _, initialState) {
+    super(id, el);
+    this.dispatch = this.dispatch.bind(this);
+    this.state = initialState;
+  }
 
-function initiateState(map, id, [reducer, initial]) {
-  const updater = makeUpdateState(current, map, id, reducer);
-  return [initial, updater];
-}
+  update(reducer) {
+    this.reducer = reducer;
+    return [this.state, this.dispatch];
+  }
 
-export const useReducer = makeState.bind(null, initiateState);
+  dispatch(action) {
+    this.state = this.reducer(this.state, action);
+    this.el._update();
+  }
+});
+
+export { useReducer };

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -19,6 +19,6 @@ export function later(fn = Function.prototype) {
   return new Promise(resolve => {
     setTimeout(() => {
       resolve(fn());
-    }, 100);
+    }, 80);
   })
 }

--- a/test/test-effects.js
+++ b/test/test-effects.js
@@ -1,0 +1,31 @@
+import { component, html, useEffect, useState } from '../web.js';
+import { attach, afterMutations, later } from './helpers.js';
+
+describe('useEffect', () => {
+  it('Memoizes values', async () => {
+    const tag = 'memo-effect-test';
+    let effects = 0;
+    let set;
+
+    function app() {
+      let [,setVal] = useState(0);
+      set = setVal;
+
+      useEffect(() => {
+        effects++;
+      }, [1])
+
+      return html`Test`;
+    }
+    customElements.define(tag, component(app));
+
+    const teardown = attach(tag);
+    await later();
+
+    set(2);
+    await later();
+    
+    assert.equal(effects, 1, 'effects ran once');
+    teardown();
+  });
+});

--- a/test/test.html
+++ b/test/test.html
@@ -14,6 +14,7 @@
 <script type="module" src="./test-npm.js"></script>
 <script type="module" src="./test-export.js"></script>
 <script type="module" src="./test-attrs.js"></script>
+<script type="module" src="./test-effects.js"></script>
 <script type="module">
   window.addEventListener('load', () => {
     mocha.run();


### PR DESCRIPTION
This allows memoization for useEffect:

```js
const [val, setVal] = useState(0);

useEffect(() => {
  document.title = `clicked ${val} times`;
}, [val]);
```

Closes #12