### PR TITLE
Support teardown in useEffect

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,49 @@ Useful for side-effects that run after the render has been commited.
 </script>
 ```
 
+#### Memoization
+
+Like `useMemo`, `useEffect` can take a second argument that are values that are memoized. The effect will only run when these values change.
+
+```js
+function App() {
+  let [name, setName] = useState('Dracula');
+
+  useEffect(() => {
+    // This only occurs when name changes.
+    document.title = `Hello ${name}`;
+  }, [name]);
+
+  return html`...`;
+}
+```
+
+#### Cleaning up side-effects
+
+Since effects are used for side-effectual things and might run many times in the lifecycle of a component, `useEffect` supports returning a teardown function.
+
+An example if when you might use this is if you are setting up an event listener.
+
+```js
+function App() {
+  let [name, setName] = useState('Wolf Man');
+
+  useEffect(() => {
+    function updateNameFromWorker(ev) {
+      setName(ev.data);
+    }
+
+    worker.addEventListener('message', updateNameFromWorker);
+
+    return () => {
+      worker.addEventListener('message', updateNameFromWorker);
+    }
+  });
+
+  return html`...`;
+}
+```
+
 ### useReducer
 
 Create state that updates after being ran through a reducer function.

--- a/src/use-effect.js
+++ b/src/use-effect.js
@@ -25,11 +25,18 @@ const useEffect = hook(class extends Hook {
   caller() {
     if(this.values) {
       if(this.hasChanged()) {
-        this.callback.call(this.el);
+        this.run();
       }
     } else {
-      this.callback.call(this.el);
+      this.run();
     }
+  }
+
+  run() {
+    if(this.teardown) {
+      this.teardown();
+    }
+    this.teardown = this.callback.call(this.el);
   }
 
   hasChanged() {

--- a/test/test-effects.js
+++ b/test/test-effects.js
@@ -28,4 +28,37 @@ describe('useEffect', () => {
     assert.equal(effects, 1, 'effects ran once');
     teardown();
   });
+
+  it('Can teardown subscriptions', async () => {
+    const tag = 'teardown-effect-test';
+    let subs = [];
+    let set;
+
+    function app() {
+      let [val, setVal] = useState(0);
+      set = setVal;
+
+      useEffect(() => {
+        subs.push(val);
+        return () => {
+          subs.splice(subs.indexOf(val), 1);
+        };
+      });
+
+      return html`Test`;
+    }
+    customElements.define(tag, component(app));
+
+    const teardown = attach(tag);
+    await later();
+
+    set(1);
+    await later();
+
+    set(2);
+    await later();
+    
+    assert.equal(subs.length, 1, 'Unsubscribed on re-renders');
+    teardown();
+  })
 });


### PR DESCRIPTION
This adds support for the teardown function in useEffect. The API
mirrors that of https://reactjs.org/docs/hooks-reference.html#cleaning-up-an-effect