### PR TITLE
Teardown effects when element is removed

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -45,6 +45,15 @@ function component(renderer, BaseElement = HTMLElement) {
       this._update();
     }
 
+    disconnectedCallback() {
+      let effects = this[effectsSymbol];
+      if(effects) {
+        for(let effect of effects) {
+          effect.teardown();
+        }
+      }
+    }
+
     attributeChangedCallback(name, _, newValue) {
       Reflect.set(this, name, newValue);
     }

--- a/src/use-effect.js
+++ b/src/use-effect.js
@@ -11,9 +11,8 @@ function setEffects(el, cb) {
 const useEffect = hook(class extends Hook {
   constructor(id, el) {
     super(id, el);
-    this.caller = this.caller.bind(this);
     this.values = [];
-    setEffects(el, this.caller);
+    setEffects(el, this);
   }
 
   update(callback, values) {
@@ -22,7 +21,7 @@ const useEffect = hook(class extends Hook {
     this.values = values;
   }
 
-  caller() {
+  call() {
     if(this.values) {
       if(this.hasChanged()) {
         this.run();
@@ -33,10 +32,14 @@ const useEffect = hook(class extends Hook {
   }
 
   run() {
-    if(this.teardown) {
-      this.teardown();
+    this.teardown();
+    this._teardown = this.callback.call(this.el);
+  }
+
+  teardown() {
+    if(this._teardown) {
+      this._teardown();
     }
-    this.teardown = this.callback.call(this.el);
   }
 
   hasChanged() {

--- a/test/test-effects.js
+++ b/test/test-effects.js
@@ -60,5 +60,33 @@ describe('useEffect', () => {
     
     assert.equal(subs.length, 1, 'Unsubscribed on re-renders');
     teardown();
-  })
+  });
+
+  it('Tears-down on unmount', async () => {
+    const tag = 'teardown-effect-unmount-test';
+    let subs = [];
+
+    function app() {
+      let val = Math.random();
+
+      useEffect(() => {
+        subs.push(val);
+        return () => {
+          subs.splice(subs.indexOf(val), 1);
+        };
+      });
+
+      return html`Test`;
+    }
+
+    customElements.define(tag, component(app));
+
+    const teardown = attach(tag);
+    await later();
+
+    teardown();
+    await later();
+    
+    assert.equal(subs.length, 0, 'Torn down on unmount');
+  });
 });


### PR DESCRIPTION
When the element is removed from the page (unmounted) tear down all
effects.