### PR TITLE
Adds support for boolean attributes

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -55,7 +55,8 @@ function component(renderer, BaseElement = HTMLElement) {
     }
 
     attributeChangedCallback(name, _, newValue) {
-      Reflect.set(this, name, newValue);
+      let val = newValue === '' ? true : newValue;
+      Reflect.set(this, name, val);
     }
 
     _update() {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -5,6 +5,13 @@ export function attach(element) {
   return () => host.removeChild(el);
 }
 
+export function mount(str) {
+  let template = document.createElement('template');
+  template.innerHTML = str;
+  host.appendChild(template.content.cloneNode(true));
+  return () => host.innerHTML = '';
+}
+
 export function afterMutations() {
   return new Promise(resolve => {
     const mo = new MutationObserver(() => {

--- a/test/test-attrs.js
+++ b/test/test-attrs.js
@@ -1,5 +1,5 @@
 import { component, html } from '../web.js';
-import { attach, afterMutations, later } from './helpers.js';
+import { attach, afterMutations, mount, later } from './helpers.js';
 
 describe('Observed attributes', () => {
   it('Trigger rerenders', async () => {
@@ -55,5 +55,28 @@ describe('Observed attributes', () => {
     let div = host.firstElementChild.shadowRoot.firstElementChild;
     assert.equal(div.textContent, 'Hello world');
     host.innerHTML =  '';
+  });
+
+  it('Boolean attributes are turned into booleans', async () => {
+    const tag = 'attrs-boolean-test';
+    let val;
+
+    function Drawer({ open }) {
+      val = open;
+      return html`Test`;
+    }
+
+    Drawer.observedAttributes = ['open'];
+
+    customElements.define(tag, component(Drawer));
+    let teardown = mount(`
+      <attrs-boolean-test open></attrs-boolean-test>
+    `);
+
+    await later();
+    teardown();
+
+    assert.equal(typeof val, 'boolean');
+    assert.equal(val, true, 'is a boolean');
   });
 })


### PR DESCRIPTION
This adds support for boolean attributes so that when something like:

```js
<drop-down open>
```

Is used it reflects as `true` and not an empty string. Closes #21