### PR TITLE
Speed up the tests

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -29,3 +29,15 @@ export function later(fn = Function.prototype) {
     }, 80);
   })
 }
+
+export function cycle() {
+  return new Promise(resolve => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          resolve();
+        });
+      });
+    });
+  });
+}

--- a/test/test-attrs.js
+++ b/test/test-attrs.js
@@ -1,5 +1,5 @@
 import { component, html } from '../web.js';
-import { attach, afterMutations, mount, later } from './helpers.js';
+import { attach, mount, cycle } from './helpers.js';
 
 describe('Observed attributes', () => {
   it('Trigger rerenders', async () => {
@@ -13,14 +13,13 @@ describe('Observed attributes', () => {
 
     customElements.define(tag, component(app));
 
-    let p = afterMutations();
     let teardown = attach(tag);
-    await later();
+    await cycle();
 
     let inst = document.querySelector(tag);
     inst.setAttribute('name', 'world');
 
-    await later();
+    await cycle();
 
     let div = host.firstChild.shadowRoot.firstElementChild;
     assert.equal(div.textContent, 'Hello world');
@@ -38,19 +37,18 @@ describe('Observed attributes', () => {
 
     customElements.define(tag, component(app));
 
-    let p = afterMutations();
     let template = document.createElement('template');
     template.innerHTML = `
       <attrs-initial-test name="world"></attrs-initial-test>
     `;
     let frag = template.content.cloneNode(true);
     host.appendChild(frag);
-    await later();
+    await cycle();
 
     let inst = document.querySelector(tag);
     inst.setAttribute('name', 'world');
 
-    await later();
+    await cycle();
 
     let div = host.firstElementChild.shadowRoot.firstElementChild;
     assert.equal(div.textContent, 'Hello world');
@@ -73,7 +71,7 @@ describe('Observed attributes', () => {
       <attrs-boolean-test open></attrs-boolean-test>
     `);
 
-    await later();
+    await cycle();
     teardown();
 
     assert.equal(typeof val, 'boolean');

--- a/test/test-effects.js
+++ b/test/test-effects.js
@@ -1,5 +1,5 @@
 import { component, html, useEffect, useState } from '../web.js';
-import { attach, afterMutations, later } from './helpers.js';
+import { attach, cycle } from './helpers.js';
 
 describe('useEffect', () => {
   it('Memoizes values', async () => {
@@ -20,10 +20,10 @@ describe('useEffect', () => {
     customElements.define(tag, component(app));
 
     const teardown = attach(tag);
-    await later();
+    await cycle();
 
     set(2);
-    await later();
+    await cycle();
     
     assert.equal(effects, 1, 'effects ran once');
     teardown();
@@ -50,13 +50,13 @@ describe('useEffect', () => {
     customElements.define(tag, component(app));
 
     const teardown = attach(tag);
-    await later();
+    await cycle();
 
     set(1);
-    await later();
+    await cycle();
 
     set(2);
-    await later();
+    await cycle();
     
     assert.equal(subs.length, 1, 'Unsubscribed on re-renders');
     teardown();
@@ -82,10 +82,10 @@ describe('useEffect', () => {
     customElements.define(tag, component(app));
 
     const teardown = attach(tag);
-    await later();
+    await cycle();
 
     teardown();
-    await later();
+    await cycle();
     
     assert.equal(subs.length, 0, 'Torn down on unmount');
   });

--- a/test/test-export.js
+++ b/test/test-export.js
@@ -1,5 +1,5 @@
 import { component, html } from '../web.js';
-import { attach, afterMutations, later } from './helpers.js';
+import { attach, cycle } from './helpers.js';
 
 describe('Component exports', () => {
   it('works', async () => {
@@ -7,12 +7,10 @@ describe('Component exports', () => {
       return html`Test`;
     }));
 
-    let p = afterMutations();
     let teardown = attach('exports-test');
+    await cycle();
 
-    return later(() => {
-      assert.equal(host.firstChild.shadowRoot.firstChild.nextSibling.nodeValue, 'Test', 'Rendered');
-      teardown();
-    });
+    assert.equal(host.firstChild.shadowRoot.firstChild.nextSibling.nodeValue, 'Test', 'Rendered');
+    teardown();
   });
 })

--- a/test/test-npm.js
+++ b/test/test-npm.js
@@ -1,6 +1,6 @@
 import { html } from '../node_modules/lit-html/lit-html.js';
 import { component } from '../web.js';
-import { attach, afterMutations } from './helpers.js';
+import { attach, cycle } from './helpers.js';
 
 describe('npm package', () => {
   it('works', async () => {
@@ -10,17 +10,10 @@ describe('npm package', () => {
       return html`Test`;
     }));
 
-    let p = afterMutations();
     let teardown = attach('npm-test');
+    await cycle();
 
-    return new Promise(resolve => {
-      setTimeout(() => {
-        assert.equal(host.firstChild.shadowRoot.firstChild.nextSibling.nodeValue, 'Test', 'Rendered');
-        teardown();
-        resolve();
-      }, 100);
-    })
-
-
+    assert.equal(host.firstChild.shadowRoot.firstChild.nextSibling.nodeValue, 'Test', 'Rendered');
+    teardown();
   });
 })


### PR DESCRIPTION
Instead of using an arbitrary time to wait, instead use a full rendering
cycle (3 animation frames) when we want to wait for a render to have
occured. In the future we can make this more granular like "wait for the
render step to complete" or "wait for the commit step to complete".
Might even be able to tie it directly into the scheduler, but for now
this is an improvement.