### PR TITLE
Adds virtual components

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,11 +47,86 @@ Haunted comes in a few builds. Pick one based on your chosen environment:
 
 ## API
 
-*Haunted* supports the same API as React Hooks. My hope is that by doing so you can reuse hooks available on npm simply by aliasing package names in your bundler's config.
+Haunted is all about writing plain functions that can contain their own state. The follow docs is divided between creating *components* (the functions) and using *hooks* the state.
+
+### Components
+
+Components are functions that contain state and return HTML via lit-html or hyperHTML. Through the `component()` and `virtual()` they become connected to a lifecycle that keeps the HTML up-to-date when state changes.
+
+Using Haunted you can create custom elements or *virtual* components (components that contain state but have no element tag).
+
+#### Custom elements
+
+The easiest way to create components is by importing `component` and creating a custom element like so:
+
+```js
+import { component } from '@matthewp/haunted';
+import { html } from 'lit-html';
+
+const App = component(({ name }) => {
+  return html`Hello ${name}!`;
+});
+
+customElements.define('my-app', App);
+```
+
+You can now use this anywhere you use HTML (directly in a `.html` file, in JSX, in lit-html templates, whereever).
+
+Here's an example of rendering with lit-html the above app:
+
+```js
+import { render, html } from 'lit-html';
+
+render(html`
+  <my-app name="world"><my-app>
+`, document.body);
+```
+
+#### Virtual components
+
+Haunted also has the concept of *virtual components*. These are components that are not defined as a tag. Rather they are functions that can be called from within another template. They have their own state and will rerender when that state changes, *without* causing any parent components to rerender.
+
+The following is an example of using virtual components:
+
+```js
+import { useState, virtual, component } from '@matthewp/haunted';
+import { html, render } from 'lit-html';
+
+const Counter = virtual(() => {
+  const [count, setCount] = useState(0);
+
+  return html`
+    <button type="button"
+      @click=${() => setCount(count + 1)}>${count}</button>
+  `;
+});
+
+const App = component(() => {
+  return html`
+    <main>
+      <h1>My app</h1>
+
+      ${Counter()}
+    </main>
+  `;
+});
+
+customElements.define('my-app', App);
+```
+
+Notice that we have `Counter`, a virtual component, and `App`, a custom element. You can use virtual components within custom elements and custom elements within virtual components.
+
+The only difference is that custom elements are used by using their `<my-app>` tag name and virtual components are called as functions.
+
+If you wanted you could create an entire app of virtual components.
+
+### Hooks
+
+Haunted supports the same API as React Hooks. The hope is that by doing so you can reuse hooks available on npm simply by aliasing package names in your bundler's config.
 
 Currently Haunted supports the following hooks:
 
-### useState
+#### useState
 
 Create a tuple of state and a function to change that state.
 
@@ -59,7 +134,7 @@ Create a tuple of state and a function to change that state.
 const [count, setCount] = useState(0);
 ```
 
-### useEffect
+#### useEffect
 
 Useful for side-effects that run after the render has been commited.
 
@@ -89,7 +164,7 @@ Useful for side-effects that run after the render has been commited.
 </script>
 ```
 
-#### Memoization
+##### Memoization
 
 Like `useMemo`, `useEffect` can take a second argument that are values that are memoized. The effect will only run when these values change.
 
@@ -106,7 +181,7 @@ function App() {
 }
 ```
 
-#### Cleaning up side-effects
+##### Cleaning up side-effects
 
 Since effects are used for side-effectual things and might run many times in the lifecycle of a component, `useEffect` supports returning a teardown function.
 
@@ -132,7 +207,7 @@ function App() {
 }
 ```
 
-### useReducer
+#### useReducer
 
 Create state that updates after being ran through a reducer function.
 
@@ -173,7 +248,7 @@ Create state that updates after being ran through a reducer function.
 </script>
 ```
 
-### useMemo
+#### useMemo
 
 Create a memoized state value. Only reruns the function when dependent values have changed.
 

--- a/src/component.js
+++ b/src/component.js
@@ -1,0 +1,76 @@
+import { Container } from './core.js';
+
+function component(renderer, BaseElement = HTMLElement) {
+  class Element extends BaseElement {
+    static get observedAttributes() {
+      return renderer.observedAttributes || [];
+    }
+
+    constructor() {
+      super();
+      this.attachShadow({ mode: 'open' });
+      this._container = new Container(renderer, this.shadowRoot, this);
+    }
+
+    connectedCallback() {
+      this._container.update();
+    }
+
+    disconnectedCallback() {
+      this._container.teardown();
+    }
+
+    attributeChangedCallback(name, _, newValue) {
+      let val = newValue === '' ? true : newValue;
+      Reflect.set(this, name, val);
+    }
+  };
+
+  function reflectiveProp(initialValue) {
+    let value = initialValue;
+    return Object.freeze({
+      enumerable: true,
+      configurable: true,
+      get() {
+        return value;
+      },
+      set(newValue) {
+        value = newValue;
+        this._container.update();
+      }
+    })
+  }
+
+  const proto = new Proxy(BaseElement.prototype, {
+    set(target, key, value, receiver) {
+      if(key in target) {
+        Reflect.set(target, key, value);
+      }
+      let desc;
+      if(typeof key === 'symbol' || key[0] === '_') {
+        desc = {
+          enumerable: true,
+          configurable: true,
+          writable: true,
+          value
+        }; 
+      } else {
+        desc = reflectiveProp(value);
+      }
+      Object.defineProperty(receiver, key, desc);
+
+      if(desc.set) {
+        desc.set.call(receiver, value);
+      }
+
+      return true;
+    }
+  });
+
+  Object.setPrototypeOf(Element.prototype, proto);
+
+
+  return Element;
+}
+
+export { component };

--- a/src/core.js
+++ b/src/core.js
@@ -1,6 +1,6 @@
 import { commitSymbol, phaseSymbol, updateSymbol, hookSymbol, effectsSymbol } from './symbols.js';
 import { setCurrent, clear } from './interface.js';
-import { render, html } from 'https://unpkg.com/lit-html@^0.13.0/lit-html.js';
+import { render, html } from './lit.js';
 
 function scheduler() {
   let tasks = [];

--- a/src/haunted.js
+++ b/src/haunted.js
@@ -1,5 +1,7 @@
-export { component, html } from './core.js';
+export { component } from './component.js';
+export { html, render } from './core.js';
 export { useEffect } from './use-effect.js';
 export { useState } from './use-state.js';
 export { useReducer } from './use-reducer.js';
 export { useMemo } from './use-memo.js';
+export { withHooks, virtual } from './virtual.js';

--- a/src/lit.js
+++ b/src/lit.js
@@ -1,0 +1,1 @@
+export * from 'https://unpkg.com/lit-html@^0.13.0/lit-html.js';

--- a/src/use-reducer.js
+++ b/src/use-reducer.js
@@ -14,7 +14,7 @@ const useReducer = hook(class extends Hook {
 
   dispatch(action) {
     this.state = this.reducer(this.state, action);
-    this.el._update();
+    this.el.update();
   }
 });
 

--- a/src/use-state.js
+++ b/src/use-state.js
@@ -13,7 +13,7 @@ const useState = hook(class extends Hook {
 
   updater(value) {
     this.makeArgs(value);
-    this.el._update();
+    this.el.update();
   }
 
   makeArgs(value) {

--- a/src/virtual.js
+++ b/src/virtual.js
@@ -1,5 +1,5 @@
 import { Container } from './core.js';
-import { directive } from 'https://unpkg.com/lit-html@^0.12.0/lit-html.js';
+import { directive } from './lit.js';
 
 class DirectiveContainer extends Container {
   commit(result) {
@@ -8,19 +8,22 @@ class DirectiveContainer extends Container {
   }
 }
 
+const map = new WeakMap();
+
 function withHooks(renderer) {
-  const inst = new WeakMap();
-  return function(...args){
-    return directive(part => {
-      let cont = inst.get(part);
+  function factory(...args) {
+    return part => {
+      let cont = map.get(part);
       if(!cont) {
         cont = new DirectiveContainer(renderer, part);
-        inst.set(part, cont);
+        map.set(part, cont);
       }
       cont.args = args;
       cont.update();
-    });
-  };
+    };
+  }
+
+  return directive(factory);
 }
 
 export { withHooks, withHooks as virtual }

--- a/src/virtual.js
+++ b/src/virtual.js
@@ -1,0 +1,26 @@
+import { Container } from './core.js';
+import { directive } from 'https://unpkg.com/lit-html@^0.12.0/lit-html.js';
+
+class DirectiveContainer extends Container {
+  commit(result) {
+    this.host.setValue(result);
+    this.host.commit();
+  }
+}
+
+function withHooks(renderer) {
+  const inst = new WeakMap();
+  return function(...args){
+    return directive(part => {
+      let cont = inst.get(part);
+      if(!cont) {
+        cont = new DirectiveContainer(renderer, part);
+        inst.set(part, cont);
+      }
+      cont.args = args;
+      cont.update();
+    });
+  };
+}
+
+export { withHooks, withHooks as virtual }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -12,6 +12,8 @@ export function mount(str) {
   return () => host.innerHTML = '';
 }
 
+export { mount as insert };
+
 export function afterMutations() {
   return new Promise(resolve => {
     const mo = new MutationObserver(() => {

--- a/test/test-virtual.js
+++ b/test/test-virtual.js
@@ -1,4 +1,4 @@
-import { html, render, useState, withHooks } from '../web.js';
+import { html, render, useState, useEffect, withHooks } from '../web.js';
 import { cycle } from './helpers.js';
 
 describe('withHooks()', () => {
@@ -114,5 +114,20 @@ describe('withHooks()', () => {
 
     let span = el.firstElementChild.firstElementChild;
     assert.equal(span.textContent, '1');
+  });
+
+  it('Can use effects', async () => {
+    let effect = false;
+    const App = withHooks(() => {
+      useEffect(() => {
+        effect = true;
+      });
+    });
+
+    let el = document.createElement('div');
+    render(App(), el);
+
+    await cycle();
+    assert.equal(effect, true, 'Effect ran within the virtual component');
   });
 });

--- a/test/test-virtual.js
+++ b/test/test-virtual.js
@@ -1,0 +1,84 @@
+import { html, render, useState, withHooks } from '../web.js';
+import { cycle } from './helpers.js';
+
+describe('withHooks()', () => {
+  it('Creates virtual components', async () => {
+    let el = document.createElement('div');
+    let set;
+
+    const App = withHooks(() => {
+      const [count, setCount] = useState(0);
+      set = setCount;
+
+      return html`<span>${count}</span>`
+    });
+
+    render(App(), el);
+
+    await cycle();
+    assert.equal(el.firstElementChild.textContent, '0');
+
+    set(1);
+    await cycle();
+    assert.equal(el.firstElementChild.textContent, '1');
+  });
+
+  it('Rendering children doesn\'t rerender the parent', async () => {
+    let el = document.createElement('div');
+    let set;
+
+    let childRenders = 0;
+    const Child = withHooks(() => {
+      childRenders++;
+      const [count, setCount] = useState(0);
+      set = setCount;
+      return html`<span id="count">${count}</span>`;
+    });
+
+    let parentRenders = 0;
+    const Parent = withHooks(() => {
+      parentRenders++;
+      
+      return html`
+        <section>${Child()}</section>
+      `;
+    });
+
+    render(Parent(), el);
+
+    await cycle();
+
+    assert.equal(parentRenders, 1);
+    assert.equal(childRenders, 1);
+
+    set(1);
+    await cycle();
+
+    assert.equal(parentRenders, 1);
+    assert.equal(childRenders, 2);
+    
+    let span = el.firstElementChild.firstElementChild;
+    assert.equal(span.textContent, "1");
+  });
+
+  it('Parent can pass args to the child', async () => {
+    let el = document.createElement('div');
+
+    const Child = withHooks((foo, baz) => {
+      return html`<span>${foo}-${baz}</span>`;
+    });
+
+    const Parent = withHooks(() => {
+      return html`
+        <section>${Child('bar', 'qux')}</section>
+      `;
+    });
+
+    render(Parent(), el);
+
+    await cycle();
+    await cycle();
+    let span = el.firstElementChild.firstElementChild;
+    assert.equal(span.textContent, 'bar-qux');
+  });
+});

--- a/test/test.html
+++ b/test/test.html
@@ -16,6 +16,8 @@
 <script type="module" src="./test-attrs.js"></script>
 <script type="module" src="./test-effects.js"></script>
 <script type="module" src="./test-props.js"></script>
+<script type="module" src="./test-virtual.js"></script>
+
 <script type="module">
   window.addEventListener('load', () => {
     mocha.run();


### PR DESCRIPTION
This adds virtual components, components that are backed by lit-html
directives.

Here's how you can use them:

```js
import { component, withHooks, useState } from '@matthewp/haunted';
import { render, html } from 'lit-html';

const Child = withHooks((foo) => {
  return html`
    <span>Foo: ${foo}</span>
  `;
});

const App = component(() => {
  return html`
    <main>
      ${Child('bar')}
    </main>
  `;
});

customElements.define('my-app', App);
```

In the above example, `App` is a custom element with the name __my-app__
while `Child` is a virtual component. You can call virtual components
like normal functions and pass them arguments. They can return a
TemplateResult (the output from lit-html). They can have event handlers
and everything that regular components can have.

If they are rerendered, for example when their state changes, it doesn't
trigger a parent to be rerendered.

Closes #27