### PR TITLE
IE11

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -1,9 +1,11 @@
-export const phaseSymbol = 'haunted.phase'
-export const hookSymbol = 'haunted.hook'
+const symbolFor = typeof Symbol === 'function' ? Symbol.for : str => str;
 
-export const updateSymbol = 'haunted.update'
-export const commitSymbol = 'haunted.commit'
-export const effectsSymbol = 'haunted.effects'
-export const contextSymbol = haunted.context'
+export const phaseSymbol = symbolFor('haunted.phase');
+export const hookSymbol = symbolFor('haunted.hook');
+
+export const updateSymbol = symbolFor('haunted.update');
+export const commitSymbol = symbolFor('haunted.commit');
+export const effectsSymbol = symbolFor('haunted.effects');
+export const contextSymbol = symbolFor('haunted.context');
 
 export const contextEvent = 'haunted.context'; 

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -1,9 +1,9 @@
-export const phaseSymbol = Symbol.for('haunted.phase');
-export const hookSymbol = Symbol.for('haunted.hook');
+export const phaseSymbol = 'haunted.phase'
+export const hookSymbol = 'haunted.hook'
 
-export const updateSymbol = Symbol.for('haunted.update');
-export const commitSymbol = Symbol.for('haunted.commit');
-export const effectsSymbol = Symbol.for('haunted.effects');
-export const contextSymbol = Symbol.for('haunted.context');
+export const updateSymbol = 'haunted.update'
+export const commitSymbol = 'haunted.commit'
+export const effectsSymbol = 'haunted.effects'
+export const contextSymbol = haunted.context'
 
 export const contextEvent = 'haunted.context'; 


### PR DESCRIPTION
Symbols aren't supported in IE11 - don't expect you to merge this, just thought I'd point it out.
What are the advantages to using symbols in this context?