### PR TITLE
Fix web.js build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ index.js: haunted.js
 	sed 's/https:\/\/unpkg\.com\/lit-html@\^1\.0\.0\/lit-html\.js/lit-html/' $^ > $@
 
 web.js: haunted.js
-	sed 's/https:\/\/unpkg\.com\/lit-html@\^1\.0\.0\/lit-html\.js/\.\.\/node_modules\/lit-html\/lit-html\.js/' $^ > $@
+	sed 's/https:\/\/unpkg\.com\/lit-html@\^1\.0\.0\/lit-html\.js/\.\.\/lit-html\/lit-html\.js/' $^ > $@
 
 clean:
 	@rm -f haunted.js index.js web.js


### PR DESCRIPTION
This fixes the web.js build so that it correctly finds lit-html assuming
both are sitting inside of node_modules. Closes #62