### PR TITLE
Use MutationObserver to teardown virtual components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 addons:
-  firefox: "63.0"
+  chrome: stable

--- a/lit-html
+++ b/lit-html
@@ -1,0 +1,1 @@
+node_modules/lit-html

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "make",
     "preversion": "make",
-    "testee": "testee --browsers firefox test/test.html",
+    "testee": "testee --browsers chrome test/test.html --config=testee.json",
     "test": "npm run build && npm run testee"
   },
   "files": [

--- a/test/debug/virtual-teardown.html
+++ b/test/debug/virtual-teardown.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Haunted</title>
+  </head>
+  <body>
+    <counter-app></counter-app>
+    <script type="module">
+import { html, render } from "https://unpkg.com/lit-html/lit-html.js";
+import {
+  component,
+  useEffect,
+  virtual,
+  useState
+} from "../src/haunted.js";
+
+const Counter = () => {
+  useEffect(() => {
+    console.log("connected component");
+    return () => {
+      console.log("disconnected component");
+    };
+  }, []);
+  const [count, setCount] = useState(0);
+
+  return html`
+    <button type="button" @click="${() => setCount(count + 1)}">
+      Count: ${count}
+    </button>
+  `;
+};
+
+customElements.define("component-counter", component(Counter));
+
+const Main = () => {
+  const [show, toggle] = useState(true);
+  const [show2, toggle2] = useState(true);
+  return html`
+    Component:
+    <button @click="${() => toggle(!show)}">${show ? "Hide" : "Show"}</button>
+    ${
+      show
+        ? html`
+            <component-counter></component-counter>
+          `
+        : undefined
+    } <br /><br />
+    Virtual:
+    <button @click="${() => toggle2(!show2)}">
+      ${show2 ? "Hide" : "Show"}
+    </button>
+    ${show2 ? virtual(Counter)() : undefined}
+  `;
+};
+
+customElements.define("counter-app", component(Main));
+    
+    </script>
+  </body>
+</html>

--- a/test/test-shadow.js
+++ b/test/test-shadow.js
@@ -1,4 +1,4 @@
-import { html } from '../node_modules/lit-html/lit-html.js';
+import { html } from '../lit-html/lit-html.js';
 import { component } from '../web.js';
 import { attach, cycle } from './helpers.js';
 

--- a/testee.json
+++ b/testee.json
@@ -1,0 +1,8 @@
+{
+  "browser": "chrome",
+  "args": [
+    "--headless",
+    "--disable-gpu",
+    "--remote-debugging-port=9222"
+  ]
+}


### PR DESCRIPTION
Directives do not have a lifecycle API. So to know when they are
removed, and call the appropriate useEffect teardown functions we now
use MutationObserver.

We do a little dance that goes like this:

* MutationObserver for when the directive node is removed from its
parent DocumentFragment (internal to lit-html).
* MutationObserver for when the directive is inserted into shadow DOM
(or whatever else I suppose).
* MutationObserver for when removed.

The last is when teardown is called. Fixes #69