### PR TITLE
Fix useEffect typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export function component(renderer: (el: HTMLElement) => TemplateResult, BaseEle
 
 export function useCallback(fn: Function, inputs: any[]): Function;
 
-export function useEffect(fn: () => Function | void): void;
+export function useEffect(fn: () => Function | void, inputs?: any[]): void;
 
 export function useState(intialValue?: any): [any, Function];
 


### PR DESCRIPTION
When using `haunted` in a TS project I noticed that the `.d.ts` does not seem to have a typing for the dependencies array. At first I assumed `haunted` just didn't support one, but it seems like form looking at other issues / the code that it does? It definitely works without it so I have set it as optional in the types.