### PR TITLE
Add support for the delegatesFocus option when attaching the Shadow DOM

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,11 @@ import { html, render, TemplateResult } from 'lit-html';
 export { html, render, TemplateResult }    
 
 export function component(renderer: (el: HTMLElement) => TemplateResult, BaseElement?: Function, options?: {
-    useShadowDOM: boolean
+    useShadowDOM: boolean,
+    shadowRootInit?: {
+        mode?: string
+        delegatesFocus?: boolean,
+    }
 }): Function;
 
 export function useCallback(fn: Function, inputs: any[]): Function;

--- a/src/component.js
+++ b/src/component.js
@@ -6,7 +6,7 @@ function toCamelCase(val = '') {
   },'') 
 }
 
-function component(renderer, BaseElement = HTMLElement, options = {useShadowDOM: true}) {
+function component(renderer, BaseElement = HTMLElement, {useShadowDOM = true, shadowRootInit = {}} = {}) {
   class Element extends BaseElement {
     static get observedAttributes() {
       return renderer.observedAttributes || [];
@@ -14,10 +14,10 @@ function component(renderer, BaseElement = HTMLElement, options = {useShadowDOM:
 
     constructor() {
       super();
-      if (options.useShadowDOM === false) {
+      if (useShadowDOM === false) {
         this._container = new Container(renderer, this);
       } else {
-        this.attachShadow({ mode: 'open' });
+        this.attachShadow({ mode: "open", ...shadowRootInit});
         this._container = new Container(renderer, this.shadowRoot, this);        
       }
     }

--- a/test/test-shadow.js
+++ b/test/test-shadow.js
@@ -27,4 +27,28 @@ describe('Shadow DOM', () => {
     teardown();
   });
 
+  it('defaults to not delegating focus from the Shadow DOM', async () => {
+    customElements.define('default-delegates-focus', component(() => {
+      return html`does not delegate focus`;
+    }));
+
+    let teardown = attach('default-delegates-focus');
+    await cycle();
+
+    assert.equal(host.firstChild.shadowRoot.delegatesFocus, false, 'Does not delegate focus from the Shadow DOM');
+    teardown();
+  })
+
+  it('allows delegating focus from the Shadow DOM', async () => {
+    customElements.define('delegates-focus', component(() => {
+      return html`delegates focus`;
+    }, HTMLElement, {shadowRootInit: {delegatesFocus: true}));
+
+    let teardown = attach('delegates-focus');
+    await cycle();
+
+    assert.equal(host.firstChild.shadowRoot.delegatesFocus, true, 'Delegates focus from the Shadow DOM');
+    teardown();
+  })
+
 })


### PR DESCRIPTION
Fixes: #89 

See https://developers.google.com/web/fundamentals/web-components/shadowdom#focus