### PR TITLE
Typescript context type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,13 +22,13 @@ export function useMemo(fn: Function, values: any[]): any;
 export function withHooks(renderer: Function): Function;
 export function virtual(renderer: Function): Function;
 
-interface Context {
+interface Context<T> {
     Provider: Function;
     Consumer: Function;
-    defaultValue: any;
+    defaultValue: T;
 }
-export function createContext(defaultValue: any): Context
-export function useContext(Context: Context): any
+export function createContext<T = any>(defaultValue: T): Context<T>
+export function useContext<T>(Context: Context<T>): T
 
 export function hook(Hook: Function): Function;
 export class Hook {

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ export function useMemo(fn: Function, values: any[]): any;
 export function withHooks(renderer: Function): Function;
 export function virtual(renderer: Function): Function;
 
-interface Context<T> {
+export interface Context<T> {
     Provider: Function;
     Consumer: Function;
     defaultValue: T;


### PR DESCRIPTION
1. Fix [issue](https://github.com/matthewp/haunted/issues/93) with missing export for the `Context interface` that prevented creating `.d.ts` files for published projects.

2. Added generics type for the `createContext()` util to allow `useContext()` to infer the context type correctly:
```ts
import {createContext, useContext} from 'haunted'

export const dataStoreContext = createContext<DataStore>({...})

const dataStore = useContext(dataStoreContext) // $ExpectType DataStore
```

3. I also thought about changing the `Context.Provider` and `Context.Consumer` from simple `Function` types, but I'm not sure what would that actually mean, because these functions constructors are inserted into the `customElements.define` and I'm not sure how or what would make the auto-complete or validation of the template relate to these types...
