### PR TITLE
Implement lazy useState

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,14 @@ Create a tuple of state and a function to change that state.
 const [count, setCount] = useState(0);
 ```
 
+Additionally you can provide a function as the argument to useState, in which case the function is called to initialize the first state, but never called again.
+
+```js
+const [count, setCount] = useState(() => {
+  return expensiveFunction();
+});
+```
+
 #### useEffect
 
 Useful for side-effects that run after the render has been commited.

--- a/src/use-state.js
+++ b/src/use-state.js
@@ -4,6 +4,11 @@ const useState = hook(class extends Hook {
   constructor(id, el, initialValue) {
     super(id, el);
     this.updater = this.updater.bind(this);
+
+    if(typeof initialValue === 'function') {
+      initialValue = initialValue();
+    }
+
     this.makeArgs(initialValue);
   }
 

--- a/test/test-effects.js
+++ b/test/test-effects.js
@@ -109,5 +109,6 @@ describe('useEffect', () => {
     document.querySelector(tag).prop = 'foo';
     await cycle();
     assert.equal(calls, 1, 'still called once');
+    teardown();
   });
 });

--- a/test/test-shadow.js
+++ b/test/test-shadow.js
@@ -42,7 +42,7 @@ describe('Shadow DOM', () => {
   it('allows delegating focus from the Shadow DOM', async () => {
     customElements.define('delegates-focus', component(() => {
       return html`delegates focus`;
-    }, HTMLElement, {shadowRootInit: {delegatesFocus: true}));
+    }, HTMLElement, {shadowRootInit: {delegatesFocus: true} }));
 
     let teardown = attach('delegates-focus');
     await cycle();

--- a/test/test-use-state.js
+++ b/test/test-use-state.js
@@ -1,0 +1,30 @@
+import { component, html, useState } from '../web.js';
+import { attach, cycle } from './helpers.js';
+
+describe('useState', () => {
+  it('Lazy callback', async () => {
+    const tag = 'use-state-callback';
+    let setter;
+
+    function App() {
+      let [age, setAge] = useState(() => 8);
+      setter = setAge;
+      return html`<span>${age}</span>`;
+    }
+
+    customElements.define(tag, component(App));
+
+    const teardown = attach(tag);
+
+    await cycle();
+    let span = host.firstChild.shadowRoot.firstElementChild;
+    assert.equal(span.textContent, '8', 'initial value');
+
+    setter(33);
+
+    await cycle();
+    assert.equal(span.textContent, '33', 'updated value');
+
+    teardown();
+  });
+});

--- a/test/test.html
+++ b/test/test.html
@@ -20,6 +20,7 @@
 <script type="module" src="./test-virtual.js"></script>
 <script type="module" src="./test-context.js"></script>
 <script type="module" src="./test-custom-hook.js"></script>
+<script type="module" src="./test-use-state.js"></script>
 
 <script type="module">
   window.addEventListener('load', () => {


### PR DESCRIPTION
This adds the ability to provide a function as the argument to useState.
Doing so the function is only called the first time useState is run.
This is meant for expensive operations that you do not want called
multiple times (a little like useMemo).

Closes #82