### PR TITLE
Typings place

### DIFF
--- a/lib/haunted.d.ts
+++ b/lib/haunted.d.ts
@@ -7,10 +7,7 @@ export type ComponentType<P, T extends ComponentLike = HTMLElement> = new(...arg
 
 type Options = {
   useShadowDOM: boolean,
-  shadowRootInit?: {
-    mode?: string
-    delegatesFocus?: boolean,
-  }
+  shadowRootInit?: ShadowRootInit,
 }
 
 export function component<P, T extends ComponentLike = HTMLElement>(

--- a/lib/haunted.d.ts
+++ b/lib/haunted.d.ts
@@ -47,7 +47,7 @@ export class Hook<T extends ComponentLike = HTMLElement> {
     constructor(id: number,  el: T);
 }
 
-interface HookWithLifecycle<T extends ComponentLike = HTMLElement, P extends any[] = null, R = void> extends Hook<T> {
+interface HookWithLifecycle<T extends ComponentLike = HTMLElement, P extends any[] = [], R = void> extends Hook<T> {
     update?(...args: P): R;
     teardown?(): void;
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/matthewp/haunted/issues"
   },
   "homepage": "https://github.com/matthewp/haunted#readme",
-  "typings": " lib/haunted.d.ts",
+  "typings": "lib/haunted.d.ts",
   "devDependencies": {
     "@matthewp/compile": "^2.4.3",
     "http-server": "^0.11.1",


### PR DESCRIPTION
Hi !
This PR modifies type definitions only.
It fixes a typo in the _package.json_ "typings" field, which prevents Typescript compiler from finding the definition file.
It also changes the `shadowRootInit` option to use the "native" `ShadowRootInit` type, making the type more precise (`mode` is either `"open"` or `"closed"` instead of any string).