### PR TITLE
Fix typedef for virtual components with props

### DIFF
--- a/lib/haunted.d.ts
+++ b/lib/haunted.d.ts
@@ -31,7 +31,7 @@ export function useMemo<T>(fn: () => T, values: any[]): T;
 
 export function useRef<T>(initialValue: T): { current: T};
 
-export function virtual<P, T extends ComponentLike = HTMLElement>(renderer: (this: T, el: P) => TemplateResult | void): () => DirectiveFactory;
+export function virtual<P, T extends ComponentLike = HTMLElement>(renderer: (this: T, el: P) => TemplateResult | void): (p: P) => DirectiveFactory;
 
 export interface Context<T> {
     Provider: ComponentType<T>;


### PR DESCRIPTION
When using virtual components that expect parameters there is a typescript error: 

<img width="829" alt="Screenshot 2019-09-18 at 10 54 22" src="https://user-images.githubusercontent.com/126038/65128826-d764ad80-da02-11e9-9003-d40db294dc45.png">

<img width="575" alt="Screenshot 2019-09-18 at 10 54 06" src="https://user-images.githubusercontent.com/126038/65128834-dd5a8e80-da02-11e9-9ec9-a9b6ac05b402.png">

This small change in the types fixes the type error. There is not change in the actual runnable code and the props/params sent to the virtual component work as intended. 

After this small fix I no longer have type errors when passing props.

<img width="454" alt="Screenshot 2019-09-18 at 10 54 33" src="https://user-images.githubusercontent.com/126038/65128894-f7946c80-da02-11e9-9c2a-b9bbe00a219e.png">
