### PR TITLE
Allow the "title" attribute to be reflected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: haunted.js web.js
 lib/*.js: src/*.ts
 	$(TRANSPILE)
 	# Add ".js" extension to module imports
-	gsed -i -E "s/from '.\/(.*?)'/from '.\/\1.js'/" lib/*.js
+	sed -i -E "s/from '.\/(.*?)'/from '.\/\1.js'/" lib/*.js
 
 haunted.js: lib/*.js
 	$(COMPILE) -f es -o $@ -e lit-html lib/haunted.js

--- a/test/test-attrs.js
+++ b/test/test-attrs.js
@@ -26,6 +26,25 @@ describe('Observed attributes', () => {
     teardown();
   });
 
+  it('Can observe the "title" attribute', async () => {
+    const tag = 'attrs-test-title';
+
+    function app() {
+      this.setAttribute('title', 'bar');
+    }
+
+    app.observedAttributes = ['title'];
+
+    customElements.define(tag, component(app));
+
+    let teardown = attach(tag);
+    await cycle();
+
+    let inst = document.querySelector(tag);
+    assert.equal(inst.getAttribute('title'), 'bar', 'on the instance');
+    teardown();
+  });
+
   it('Trigger rerenders while declared as an option', async () => {
     const tag = 'attrs-options-test';
 


### PR DESCRIPTION
This was a bug related to the `title` global attribute.