### PR TITLE
Fail gracefully from `useMemo`

### DIFF
--- a/src/use-memo.ts
+++ b/src/use-memo.ts
@@ -19,7 +19,7 @@ const useMemo = hook(class<T> extends Hook {
     return this.value;
   }
 
-  hasChanged(values: unknown[]): boolean {
+  hasChanged(values: unknown[] = []): boolean {
     return values.some((value, i) => this.values[i] !== value);
   }
 });


### PR DESCRIPTION
Default `values` to an empty array in `hasChanged` to prevent a cryptic error from being thrown. This is more in line with the way React handles `useMemo`/`useCallback`.

This fixes #152