### PR TITLE
Default attribute type converter, declare type and convert before update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -164,7 +164,7 @@ Which allows you to author (in HTML):
 <hello-app name="world"></hello-app>
 ```
 
-##### Attributes type coercion
+##### Attributes type converter
 
 Default converter will handle `String`, `Number`, `Array`, `Object`, `Boolean` types, please speicify attribute `name` & `type` in `observedAttributes` of options like below.
 

--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,23 @@ Which allows you to author (in HTML):
 <hello-app name="world"></hello-app>
 ```
 
+##### Attributes type coercion
+
+Default converter will handle `String`, `Number`, `Array`, `Object`, `Boolean` types, please speicify attribute `name` & `type` in `observedAttributes` of options like below.
+
+```js
+customElements.define('hello-app', component(App, {
+  observedAttributes: [{
+    name: "username",
+    type: String
+  }, {
+    name: "userage",
+    type: Number
+  }]
+}));
+```
+The value will be converted before component update.
+
 #### Virtual components
 
 Haunted also has the concept of *virtual components*. These are components that are not defined as a tag. Rather they are functions that can be called from within another template. They have their own state and will rerender when that state changes, *without* causing any parent components to rerender.

--- a/src/component.ts
+++ b/src/component.ts
@@ -66,15 +66,16 @@ function makeComponent(render: RenderFunction): Creator {
     const _observedAttributes =
       renderer.observedAttributes || observedAttributes || [];
 
-    const props  = _observedAttributes.map( item => {
-      if(typeof item === 'string') return ({
-        type: "legacy",
-        name: item
-      })
-      return item;
-    })
-    const finalObservedAttribute = props.map( (prop:any) => prop.name);
-    
+    const props = _observedAttributes.map(item =>
+      typeof item === 'string'
+        ? {
+            type: 'legacy',
+            name: item
+          }
+        : item
+    );
+    const finalObservedAttribute = props.map((prop: any) => prop.name);
+ 
     class Element extends BaseElement {
       _scheduler: Scheduler<P>;
 

--- a/test/test-attrs.js
+++ b/test/test-attrs.js
@@ -67,6 +67,52 @@ describe('Observed attributes', () => {
     teardown();
   });
 
+  
+  it("Type convert before rerenders trigger", async () => {
+    const tag = "attr-type-converter";
+    function app({ name = "" }) {
+      return html`
+        <div>Hello ${name}</div>
+      `;
+    }
+    customElements.define(
+      tag,
+      component(app, {
+        observedAttributes: [
+          { name: "str", type: String },
+          { name: "num", type: Number },
+          { name: "arr", type: Array },
+          { name: "obj", type: Object },
+          { name: "bool", type: Boolean }
+        ]
+      })
+    );
+    let teardown = attach(tag);
+    await cycle();
+    let inst = document.querySelector(tag);
+    // Attribute set
+    inst.setAttribute("str", "foo");
+    inst.setAttribute("num", "100");
+    inst.setAttribute("arr", "[1,2,3]");
+    inst.setAttribute("obj", `{"a":2}`);
+    inst.setAttribute("bool", '');
+    await cycle();
+    // Assert type
+    assert.equal(typeof inst.str, "string");
+    assert.equal(typeof inst.num, "number");
+    assert.equal(Array.isArray(inst.arr), true);
+    assert.equal(typeof inst.obj, "object");
+    assert.equal(typeof inst.bool, "boolean");
+    // Assert value
+    assert.equal(inst.str, "foo");
+    assert.equal(inst.num, 100);
+    assert.equal(inst.arr[0], 1);
+    assert.equal(inst.obj.a, 2);
+    assert.equal(inst.bool, true)
+    teardown();
+  });
+
+
   it('Initial attributes are reflected', async () => {
     const tag = 'attrs-initial-test';
 


### PR DESCRIPTION
### Goal
It's a POC of this https://github.com/matthewp/haunted/issues/74#issuecomment-562974123 

### Implement 
I tried to make changes minimum, to prevent breaking the original usage I use mapping function twice, to collect the attribute object from original and new interface.
Same as in `converter` function, it has a type named `legacy` is for original interface.

### Improvement
If you think this interface / implement is ok, please give me advice about the variables name and specific & correct interface about it.
