### PR TITLE
add initializer argument to useReducer

### DIFF
--- a/src/use-reducer.ts
+++ b/src/use-reducer.ts
@@ -3,14 +3,14 @@ import { State } from './state';
 
 type Reducer<S, A> = (state: S, action: A) => S;
 
-const useReducer = hook(class<S, A> extends Hook {
+const useReducer = hook(class<S, I, A> extends Hook {
   reducer!: Reducer<S, A>;
   currentState: S;
 
-  constructor(id: number, state: State, _: Reducer<S, A>, initialState: S, initializer?: (_: S) => S) {
+  constructor(id: number, state: State, _: Reducer<S, A>, initialState: I, init?: (_:I) => S) {
     super(id, state);
     this.dispatch = this.dispatch.bind(this);
-    this.currentState = initializer ? initializer(initialState) : initialState;
+    this.currentState = init !== undefined ? init(initialState) : <S><any>initialState;
   }
 
   update(reducer: Reducer<S, A>): readonly [S, (action: A) => void] {

--- a/src/use-reducer.ts
+++ b/src/use-reducer.ts
@@ -7,10 +7,10 @@ const useReducer = hook(class<S, A> extends Hook {
   reducer!: Reducer<S, A>;
   currentState: S;
 
-  constructor(id: number, state: State, _: Reducer<S, A>, initialState: S) {
+  constructor(id: number, state: State, _: Reducer<S, A>, initialState: S, initializer?: (_: S) => S) {
     super(id, state);
     this.dispatch = this.dispatch.bind(this);
-    this.currentState = initialState;
+    this.currentState = initializer ? initializer(initialState) : initialState;
   }
 
   update(reducer: Reducer<S, A>): readonly [S, (action: A) => void] {

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -81,10 +81,12 @@ const [state2, setState2] = useState(undefined); setState2 + 1;
 // useReducer tests
 // positive tests, should all pass
 useReducer(() => {}, undefined);
-useReducer((state: number) => state, 1)
+useReducer((state: number) => state, 1);
+useReducer((state: string) => state, 1, (value: number) => value.toString());
 // negactive tests, should all fail
 useReducer();
 const useReducerTest1 = useReducer(() => {});
+useReducer((state: string) => state, 1, (value: Date) => value.toString());
 useReducerTest1 + 1;
 
 // useMemo tests


### PR DESCRIPTION
added this third argument to useReducer so it can be used in the same manner as the example here: https://reactjs.org/docs/hooks-reference.html#usereducer 