### PR TITLE
fix: added teardown effects in LitHaunted docs/example

### DIFF
--- a/examples/lit/lit-haunted-element.js
+++ b/examples/lit/lit-haunted-element.js
@@ -10,6 +10,12 @@ export default class LitHauntedElement extends LitElement {
 
   update(changedProperties) {
     this.haunted.run(() => super.update(changedProperties));
+    this.haunted.runEffects();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.haunted.teardown();
   }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -531,6 +531,11 @@ export default class LitHauntedElement extends LitElement {
     this.hauntedState.run(() => super.update(changedProperties));
     this.hauntedState.runEffects();
   }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.hauntedState.teardown();
+  }
 }
 ```
 


### PR DESCRIPTION
Improved docs of how to use LitHauntedElement. The effects of LitHauntedElement docs/example were not being cleaned up.