### PR TITLE
Touch up and standardize README examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,7 @@ If you install Haunted **locally** this build is located at `node_modules/haunte
 
 ## API
 
-Haunted is all about writing plain functions that can contain their own state. The follow docs is divided between creating _components_ (the functions) and using _hooks_ the state.
+Haunted is all about writing plain functions that can contain their own state. The documentation below is separated into two sections: creating _components_ (the functions) and using _hooks_ to manage state.
 
 ### Components
 
@@ -127,7 +127,7 @@ Using Haunted you can create custom elements or _virtual_ components (components
 
 #### Custom elements
 
-A Custom Element can be defined via haunted by passing your custom component you defined (e.g. `function App() {}`) to haunted's `component` function. You then take the result of your call to `component` and pass it to `customElements.define` like so:
+A custom element can be defined via haunted by passing your component you defined (e.g. `function App() {}`) to haunted's `component` function. You then take the result of your call to `component` and pass it to `customElements.define` like so:
 
 ```js
 function App({ name }) {

--- a/readme.md
+++ b/readme.md
@@ -83,9 +83,7 @@ const { component } = haunted({
 
 function App() {
   const [count, setCount] = useState(0);
-  return html`
-    Using lighterhtml! Count: ${count}
-  `;
+  return html`Using lighterhtml! Count: ${count}`;
 }
 
 customElements.define("my-app", component(App));
@@ -128,9 +126,7 @@ A Custom Element can be defined via haunted by passing your custom component you
 
 ```js
 function App({ name }) {
-  return html`
-    Hello ${name}
-  `;
+  return html`Hello ${name}`;
 }
 
 customElements.define("my-app", component(App));
@@ -147,9 +143,7 @@ There's no way to use the `this` keyword to refer to the instance of your web co
 ```js
 const App = ({ name }) => {
   console.log(this); // => "undefined"
-  return html`
-    Hello ${name}!
-  `;
+  return html`Hello ${name}!`;
 };
 ```
 
@@ -163,9 +157,7 @@ In this instance, we're using lit-html which comes with a `render` function. You
 import { render, html } from "lit-html";
 
 render(
-  html`
-    <my-app name="world"></my-app>
-  `,
+  html`<my-app name="world"></my-app>`,
   document.body
 );
 ```
@@ -445,9 +437,7 @@ Create and returns an object with one property "current" which can be assigned a
   function App() {
     const myRef = useRef(0);
 
-    return html`
-      ${myRef.current}
-    `;
+    return html`${myRef.current}`;
   }
 
   customElements.define("my-app", component(App));
@@ -501,9 +491,8 @@ Limited only to "real" components for now.
         <theme-provider .value=${theme === "dark" ? "light" : "dark"}>
           <theme-consumer
             .render=${value =>
-              html`
-                <h1>${value}</h1>
-              `}
+              html`<h1>${value}</h1>`
+            }
           ></theme-consumer>
         </theme-provider>
       </theme-provider>

--- a/readme.md
+++ b/readme.md
@@ -202,28 +202,33 @@ const Counter = virtual(() => {
   const [count, setCount] = useState(0);
 
   return html`
-    <button type="button" @click=${() => setCount(count + 1)}>${count}</button>
+    <button type="button" @click=${() => setCount(count + 1)}>
+      ${count}
+    </button>
   `;
 });
 
-const App = component(() => {
+function App() {
   return html`
     <main>
       <h1>My app</h1>
-
       ${Counter()}
     </main>
   `;
-});
+}
 
-customElements.define("my-app", App);
+customElements.define("my-app", component(App));
 ```
 
 Notice that we have `Counter`, a virtual component, and `App`, a custom element. You can use virtual components within custom elements and custom elements within virtual components.
 
-The only difference is that custom elements are used by using their `<my-app>` tag name and virtual components are called as functions.
+The only difference is that custom elements are used by using their tag name (e.g. `<my-app>`) and virtual components are called as functions.
 
 If you wanted you could create an entire app of virtual components.
+
+##### Virtual components and `this`
+
+You'll notice that in the above examples, we're using the fat arrow syntax. This is due to virtual components not being attached to any actual custom elements, therefore, `this` never points to anything negating the purpose of using the function syntax.
 
 ### Hooks
 
@@ -296,9 +301,7 @@ function App() {
     document.title = `Hello ${name}`;
   }, [name]);
 
-  return html`
-    ...
-  `;
+  return html`...`;
 }
 ```
 
@@ -324,9 +327,7 @@ function App() {
     };
   });
 
-  return html`
-    ...
-  `;
+  return html`...`;
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -424,7 +424,9 @@ Create a memoized state value. Only reruns the function when dependent values ha
 
 #### useRef
 
-Create and returns an object with one property "current" which can be assigned any value and is unaffected by multiple renders.
+Creates and returns a mutable object (a 'ref') whose `.current` property is initialized to the passed argument.
+
+This differs from `useState` in that state is immutable and can only be changed via `setState` which **will** cause a rerender. That rerender will allow you to be able to see the updated `state` value. A ref, on the other hand, can only be changed via `.current` and since changes to it are mutations, no rerender is required to view the updated value in your component's code (e.g. listeners, callbacks, effects).
 
 ```html
 <!DOCTYPE html>

--- a/readme.md
+++ b/readme.md
@@ -308,7 +308,7 @@ useEffect(() => {
 
 Since effects are used for side-effectual things and might run many times in the lifecycle of a component, `useEffect` supports returning a teardown function.
 
-An example of when you might use this is if you are setting up an event listener.
+An example of when you might use this is if you are setting up an event listener:
 
 ```js
 const [name, setName] = useState('Wolf Man');
@@ -330,13 +330,16 @@ useEffect(() => {
 
 The function signature is the same as `useEffect`, but the callback is being called synchronously after rendering. Therefore, updates scheduled inside `useLayoutEffect` will be flushed synchronously before the browser has a chance to paint.
 
-Most of time, it is preferable to use `useEffect` to avoid blocking visual updates.
+Most of the time, it is preferable to use `useEffect` to avoid blocking visual updates.
 
 #### useReducer
 
-Create state that updates after being ran through a reducer function.
+Similarly to `useState`, `useReducer` will return an array of two values, the first one being the state. The second one, however, is `dispatch`. This is a function that takes an **action**. The action is then passed to your **reducer** (the first argument) and your reducer will determine the new state and return it.
+
+The following is an example of `useReducer` being used to handle incrementing and decrementing a count:
 
 ```js
+// doesn't have to be an object, could just be `initialState = 0`
 const initialState = { count: 0 };
 
 function reducer(state, action) {
@@ -363,6 +366,8 @@ function Counter() {
   `;
 }
 ```
+
+This might look familiar as [redux](https://redux.js.org/) uses a similar concept.
 
 #### useMemo
 

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ import {
   component,
   useState,
   useMemo,
+  useCallback,
   useEffect,
   useLayoutEffect,
   useReducer,
@@ -505,6 +506,22 @@ function App() {
     <div>Fibonacci <strong>${fib}</strong></div>
   `;
 }
+```
+
+#### useCallback
+
+Very similar to `useMemo` but instead of writing a function that returns your memoized value, your function is the memoized value. This and `useMemo` are often overused so try to only use this when your callback has dependencies and it is itself a dependency for something else (like `useEffect`) .
+
+```js
+const submit = useCallback(event => {
+  event.preventDefault();
+  api.post('submit', { email, password });
+}, [email, password]);
+
+useEffect(() => {
+  this.addEventListener('submit', submit);
+  return () => this.removeEventListener('submit', submit);
+}, [submit]);
 ```
 
 #### useRef

--- a/readme.md
+++ b/readme.md
@@ -153,7 +153,7 @@ const App = ({ name }) => {
 
 ##### Rendering
 
-Now that we have access to `<my-app>` in all HTML, what if you want to render it from JavaScript?
+Now that we have access to `<my-app>` anywhere we can write HTML, what if you want to render it from JavaScript?
 
 In this instance, we're using lit-html which comes with a `render` function. You can utilize it by passing in your HTML template and the element you wish to render the template into:
 

--- a/readme.md
+++ b/readme.md
@@ -226,7 +226,7 @@ function App() {
 }
 ```
 
-Notice that it is encouraged to use camel case here instead of kebab case as these aren't attributes, they're properties that you'll most likely be using as variables at some point.
+Notice that it is encouraged to use camel case when writing your template instead of kebab case as these aren't attributes. They're properties so they won't be automatically rewritten in camel case for you.
 
 ##### Dispatching Events
 

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ You can also use Custom Elements without Shadow DOM if you wish.
 eg.
 
 ```js
-component(() => html`...`, { useShadowDOM: false }));
+component(MyComponent, { useShadowDOM: false }));
 ```
 
 ### Importing

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
- 🦇 🎃
+🦇 🎃
 
 [![npm](https://img.shields.io/npm/dt/haunted)](https://npm.im/haunted)
 [![npm](https://img.shields.io/npm/v/haunted)](https://npm.im/haunted)
@@ -6,26 +6,28 @@
 React's Hooks API but for standard web components and [lit-html](https://lit-html.polymer-project.org/) or [hyperHTML](https://codepen.io/WebReflection/pen/pxXrdy?editors=0010).
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
+  <my-counter></my-counter>
 
-<my-counter></my-counter>
+  <script type="module">
+    import { html } from "https://unpkg.com/lit-html/lit-html.js";
+    import { component, useState } from "https://unpkg.com/haunted/haunted.js";
 
-<script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
-  import { component, useState } from 'https://unpkg.com/haunted/haunted.js';
+    function Counter() {
+      const [count, setCount] = useState(0);
 
-  function Counter() {
-    const [count, setCount] = useState(0);
+      return html`
+        <div id="count">${count}</div>
+        <button type="button" @click=${() => setCount(count + 1)}>
+          Increment
+        </button>
+      `;
+    }
 
-    return html`
-      <div id="count">${count}</div>
-      <button type="button" @click=${() => setCount(count + 1)}>Increment</button>
-    `;
-  }
-
-  customElements.define('my-counter', component(Counter));
-</script>
+    customElements.define("my-counter", component(Counter));
+  </script>
+</html>
 ```
 
 ## Getting started
@@ -38,11 +40,12 @@ A starter app is available on [codesandbox](https://codesandbox.io/s/github/matt
 npm install haunted
 ```
 
-For Internet Explorer 11, you'll need to use a proxy polyfill, in addition to the usual webcomponentsjs polyfills. 
+For Internet Explorer 11, you'll need to use a proxy polyfill, in addition to the usual webcomponentsjs polyfills.
 
 eg.
+
 ```html
-<script src="https://cdn.jsdelivr.net/npm/proxy-polyfill@0.3.0/proxy.min.js"></script> 
+<script src="https://cdn.jsdelivr.net/npm/proxy-polyfill@0.3.0/proxy.min.js"></script>
 ```
 
 For a full example with Internet Explorer 11, see - https://github.com/crisward/haunted-ie11
@@ -56,10 +59,10 @@ component(MyComponent, { useShadowDOM: false }));
 
 ### Importing
 
-__Haunted__ can be imported just like any other library when using a bundler of your choice:
+**Haunted** can be imported just like any other library when using a bundler of your choice:
 
 ```js
-import { component, html, useState } from 'haunted';
+import { component, html, useState } from "haunted";
 ```
 
 The main entry point is intended for [lit-html](https://github.com/Polymer/lit-html) users.
@@ -69,8 +72,8 @@ The main entry point is intended for [lit-html](https://github.com/Polymer/lit-h
 If you are using [lighterhtml](https://github.com/WebReflection/lighterhtml) or [hyperHTML](https://github.com/WebReflection/hyperHTML) then instead import `haunted/core`. This export gives you a function that creates Hooks that work with any template library.
 
 ```js
-import haunted, { useState } from 'haunted/core';
-import { html, render } from 'lighterhtml';
+import haunted, { useState } from "haunted/core";
+import { html, render } from "lighterhtml";
 
 const { component } = haunted({
   render(what, where) {
@@ -80,64 +83,91 @@ const { component } = haunted({
 
 function App() {
   const [count, setCount] = useState(0);
-  return html`Using lighterhtml! Count: ${count}`;
+  return html`
+    Using lighterhtml! Count: ${count}
+  `;
 }
 
-customElements.define('my-app', component(App));
+customElements.define("my-app", component(App));
 ```
 
 #### Web modules
 
-__Haunted__ can work directly in the browser without using any build tools. Simply import the `haunted.js` bundle. You can use the [unpkg] or [pika](https://www.pika.dev/cdn) CDNs. This works great for demo pages and small apps. Here's an example with unpkg:
+**Haunted** can work directly in the browser without using any build tools. Simply import the `haunted.js` bundle. You can use the [unpkg] or [pika](https://www.pika.dev/cdn) CDNs. This works great for demo pages and small apps. Here's an example with unpkg:
 
 ```js
-import { html } from 'https://unpkg.com/lit-html/lit-html.js';
-import { component, useState, useEffect } from 'https://unpkg.com/haunted/haunted.js';
+import { html } from "https://unpkg.com/lit-html/lit-html.js";
+import {
+  component,
+  useState,
+  useEffect
+} from "https://unpkg.com/haunted/haunted.js";
 ```
 
 If using pika then use the `html` export from Haunted, as pika bundles everything together:
 
 ```js
-import { useState, component, html } from 'https://cdn.pika.dev/haunted';
+import { useState, component, html } from "https://cdn.pika.dev/haunted";
 ```
 
-If you install Haunted __locally__ this build is located at `node_modules/haunted/haunted.js`.
+If you install Haunted **locally** this build is located at `node_modules/haunted/haunted.js`.
 
 ## API
 
-Haunted is all about writing plain functions that can contain their own state. The follow docs is divided between creating *components* (the functions) and using *hooks* the state.
+Haunted is all about writing plain functions that can contain their own state. The follow docs is divided between creating _components_ (the functions) and using _hooks_ the state.
 
 ### Components
 
 Components are functions that contain state and return HTML via lit-html or hyperHTML. Through the `component()` and `virtual()` they become connected to a lifecycle that keeps the HTML up-to-date when state changes.
 
-Using Haunted you can create custom elements or *virtual* components (components that contain state but have no element tag).
+Using Haunted you can create custom elements or _virtual_ components (components that contain state but have no element tag).
 
 #### Custom elements
 
-The easiest way to create components is by importing `component` and creating a custom element like so:
+A Custom Element can be defined via haunted by passing your custom component you defined (e.g. `function App() {}`) to haunted's `component` function. You then take the result of your call to `component` and pass it to `customElements.define` like so:
 
 ```js
-import { component } from 'haunted';
-import { html } from 'lit-html';
+function App({ name }) {
+  return html`
+    Hello ${name}
+  `;
+}
 
-const App = ({ name }) => {
-  return html`Hello ${name}!`;
-};
-
-customElements.define('my-app', component(App));
+customElements.define("my-app", component(App));
 ```
 
-You can now use this anywhere you use HTML (directly in a `.html` file, in JSX, in lit-html templates, whereever).
+You can now use `<my-app></my-app>` anywhere you use HTML (directly in a `.html` file, in JSX, in lit-html templates, wherever).
 
-Here's an example of rendering with lit-html the above app:
+##### Brief Digression:
+
+Another way to write your component is with the arrow function syntax, or fat arrow. It offers a more concise and clean way to write your code, however, it does come with a one drawback:
+
+There's no way to use the `this` keyword to refer to the instance of your web component that is running.
 
 ```js
-import { render, html } from 'lit-html';
+const App = ({ name }) => {
+  console.log(this); // => "undefined"
+  return html`
+    Hello ${name}!
+  `;
+};
+```
 
-render(html`
-  <my-app name="world"></my-app>
-`, document.body);
+##### Rendering
+
+Now that we have access to `<my-app>` in all HTML, what if you want to render it from JavaScript?
+
+In this instance, we're using lit-html which comes with a `render` function. You can utilize it by passing in your HTML template and the element you wish to render the template into:
+
+```js
+import { render, html } from "lit-html";
+
+render(
+  html`
+    <my-app name="world"></my-app>
+  `,
+  document.body
+);
 ```
 
 ##### Attributes
@@ -145,19 +175,22 @@ render(html`
 In custom elements, attributes must be pre-defined. Properties, on the other hand, do not. To define what attributes your component supports, set the `observedAttributes` property on the functional component. For example:
 
 ```js
-const App = ({name}) => {
+const App = ({ name }) => {
   return `Hello ${name}!`;
 };
 
-App.observedAttributes = ['name'];
+App.observedAttributes = ["name"];
 
-customElements.define('hello-app', component(App));
+customElements.define("hello-app", component(App));
 ```
 
 Alternatively, you can pass `observedAttributes` as an option to `component()`:
 
 ```js
-customElements.define('hello-app', component(App, {observedAttributes: ['name']}));
+customElements.define(
+  "hello-app",
+  component(App, { observedAttributes: ["name"] })
+);
 ```
 
 Which allows you to author (in HTML):
@@ -168,20 +201,19 @@ Which allows you to author (in HTML):
 
 #### Virtual components
 
-Haunted also has the concept of *virtual components*. These are components that are not defined as a tag. Rather they are functions that can be called from within another template. They have their own state and will rerender when that state changes, *without* causing any parent components to rerender.
+Haunted also has the concept of _virtual components_. These are components that are not defined as a tag. Rather they are functions that can be called from within another template. They have their own state and will rerender when that state changes, _without_ causing any parent components to rerender.
 
 The following is an example of using virtual components:
 
 ```js
-import { useState, virtual, component } from 'haunted';
-import { html, render } from 'lit-html';
+import { useState, virtual, component } from "haunted";
+import { html, render } from "lit-html";
 
 const Counter = virtual(() => {
   const [count, setCount] = useState(0);
 
   return html`
-    <button type="button"
-      @click=${() => setCount(count + 1)}>${count}</button>
+    <button type="button" @click=${() => setCount(count + 1)}>${count}</button>
   `;
 });
 
@@ -195,7 +227,7 @@ const App = component(() => {
   `;
 });
 
-customElements.define('my-app', App);
+customElements.define("my-app", App);
 ```
 
 Notice that we have `Counter`, a virtual component, and `App`, a custom element. You can use virtual components within custom elements and custom elements within virtual components.
@@ -231,13 +263,17 @@ const [count, setCount] = useState(() => {
 Useful for side-effects that run after the render has been commited.
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 
 <my-counter></my-counter>
 
 <script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
-  import { component, useState, useEffect } from 'https://unpkg.com/haunted/haunted.js';
+  import { html } from "https://unpkg.com/lit-html/lit-html.js";
+  import {
+    component,
+    useState,
+    useEffect
+  } from "https://unpkg.com/haunted/haunted.js";
 
   function Counter() {
     const [count, setCount] = useState(0);
@@ -248,11 +284,13 @@ Useful for side-effects that run after the render has been commited.
 
     return html`
       <div id="count">${count}</div>
-      <button type="button" @click=${() => setCount(count + 1)}>Increment</button>
+      <button type="button" @click=${() => setCount(count + 1)}>
+        Increment
+      </button>
     `;
   }
 
-  customElements.define('my-counter', component(Counter));
+  customElements.define("my-counter", component(Counter));
 </script>
 ```
 
@@ -262,14 +300,16 @@ Like `useMemo`, `useEffect` can take a second argument that are values that are 
 
 ```js
 function App() {
-  let [name, setName] = useState('Dracula');
+  let [name, setName] = useState("Dracula");
 
   useEffect(() => {
     // This only occurs when name changes.
     document.title = `Hello ${name}`;
   }, [name]);
 
-  return html`...`;
+  return html`
+    ...
+  `;
 }
 ```
 
@@ -281,21 +321,23 @@ An example of when you might use this is if you are setting up an event listener
 
 ```js
 function App() {
-  let [name, setName] = useState('Wolf Man');
+  let [name, setName] = useState("Wolf Man");
 
   useEffect(() => {
     function updateNameFromWorker(ev) {
       setName(ev.data);
     }
 
-    worker.addEventListener('message', updateNameFromWorker);
+    worker.addEventListener("message", updateNameFromWorker);
 
     return () => {
-      worker.removeEventListener('message', updateNameFromWorker);
-    }
+      worker.removeEventListener("message", updateNameFromWorker);
+    };
   });
 
-  return html`...`;
+  return html`
+    ...
+  `;
 }
 ```
 
@@ -310,22 +352,24 @@ Most of time, it is preferable to use `useEffect` to avoid blocking visual updat
 Create state that updates after being ran through a reducer function.
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 
 <my-counter></my-counter>
 
-
 <script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
-  import { component, useReducer } from 'https://unpkg.com/haunted/haunted.js';
+  import { html } from "https://unpkg.com/lit-html/lit-html.js";
+  import { component, useReducer } from "https://unpkg.com/haunted/haunted.js";
 
-  const initialState = {count: 0};
+  const initialState = { count: 0 };
 
   function reducer(state, action) {
     switch (action.type) {
-      case 'reset': return initialState;
-      case 'increment': return {count: state.count + 1};
-      case 'decrement': return {count: state.count - 1};
+      case "reset":
+        return initialState;
+      case "increment":
+        return { count: state.count + 1 };
+      case "decrement":
+        return { count: state.count - 1 };
     }
   }
 
@@ -334,15 +378,15 @@ Create state that updates after being ran through a reducer function.
 
     return html`
       Count: ${state.count}
-      <button @click=${() => dispatch({type: 'reset'})}>
+      <button @click=${() => dispatch({ type: "reset" })}>
         Reset
       </button>
-      <button @click=${() => dispatch({type: 'increment'})}>+</button>
-      <button @click=${() => dispatch({type: 'decrement'})}>-</button>
+      <button @click=${() => dispatch({ type: "increment" })}>+</button>
+      <button @click=${() => dispatch({ type: "decrement" })}>-</button>
     `;
   }
 
-  customElements.define('my-counter', component(Counter));
+  customElements.define("my-counter", component(Counter));
 </script>
 ```
 
@@ -351,13 +395,17 @@ Create state that updates after being ran through a reducer function.
 Create a memoized state value. Only reruns the function when dependent values have changed.
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 
 <my-app></my-app>
 
 <script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
-  import { component, useMemo, useState } from 'https://unpkg.com/haunted/haunted.js';
+  import { html } from "https://unpkg.com/lit-html/lit-html.js";
+  import {
+    component,
+    useMemo,
+    useState
+  } from "https://unpkg.com/haunted/haunted.js";
 
   function fibonacci(num) {
     if (num <= 1) return 1;
@@ -371,12 +419,16 @@ Create a memoized state value. Only reruns the function when dependent values ha
 
     return html`
       <h1>Fibonacci</h1>
-      <input type="text" @change=${ev => setVal(Number(ev.target.value))} value="${value}">
+      <input
+        type="text"
+        @change=${ev => setVal(Number(ev.target.value))}
+        value="${value}"
+      />
       <div>Fibonacci <strong>${fib}</strong></div>
     `;
   }
 
-  customElements.define('my-app', component(App));
+  customElements.define("my-app", component(App));
 </script>
 ```
 
@@ -385,13 +437,13 @@ Create a memoized state value. Only reruns the function when dependent values ha
 Create and returns an object with one property "current" which can be assigned any value and is unaffected by multiple renders.
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 
 <my-app></my-app>
 
 <script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
-  import { component, useRef } from 'https://unpkg.com/haunted/haunted.js';
+  import { html } from "https://unpkg.com/lit-html/lit-html.js";
+  import { component, useRef } from "https://unpkg.com/haunted/haunted.js";
 
   function App() {
     const myRef = useRef(0);
@@ -401,7 +453,7 @@ Create and returns an object with one property "current" which can be assigned a
     `;
   }
 
-  customElements.define('my-app', component(App));
+  customElements.define("my-app", component(App));
 </script>
 ```
 
@@ -411,18 +463,22 @@ Grabs context value from the closest provider up in the tree and updates compone
 Limited only to "real" components for now.
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 
 <my-app></my-app>
 
 <script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
-  import { component, createContext, useContext } from 'https://unpkg.com/haunted/haunted.js';
+  import { html } from "https://unpkg.com/lit-html/lit-html.js";
+  import {
+    component,
+    createContext,
+    useContext
+  } from "https://unpkg.com/haunted/haunted.js";
 
-  const ThemeContext = createContext('dark');
+  const ThemeContext = createContext("dark");
 
-  customElements.define('theme-provider', ThemeContext.Provider);
-  customElements.define('theme-consumer', ThemeContext.Consumer);
+  customElements.define("theme-provider", ThemeContext.Provider);
+  customElements.define("theme-consumer", ThemeContext.Consumer);
 
   function Consumer() {
     const context = useContext(ThemeContext);
@@ -430,35 +486,34 @@ Limited only to "real" components for now.
     return context;
   }
 
-  customElements.define('my-consumer', component(Consumer));
+  customElements.define("my-consumer", component(Consumer));
 
   function App() {
-    const [theme, setTheme] = useState('light');
-    
+    const [theme, setTheme] = useState("light");
+
     return html`
-      <select value=${theme} @change=${(e) => setTheme(e.target.value)}>
+      <select value=${theme} @change=${e => setTheme(e.target.value)}>
         <option value="dark">Dark</option>
         <option value="light">Light</option>
       </select>
-      
+
       <theme-provider .value=${theme}>
-        
         <my-consumer></my-consumer>
 
         <!-- creates context with inverted theme -->
-        <theme-provider .value=${theme === 'dark' ? 'light' : 'dark'}> 
-          
+        <theme-provider .value=${theme === "dark" ? "light" : "dark"}>
           <theme-consumer
-            .render=${value => html`<h1>${value}</h1>`}
+            .render=${value =>
+              html`
+                <h1>${value}</h1>
+              `}
           ></theme-consumer>
-        
         </theme-provider>
-      
       </theme-provider>
     `;
   }
 
-  customElements.define('my-app', component(App));
+  customElements.define("my-app", component(App));
 </script>
 ```
 
@@ -495,7 +550,7 @@ It has a signature of: `new State(update, [ hostElement ])`.
 Here's an example how it can be used to run hooks code:
 
 ```js
-import { State, useState } from 'haunted';
+import { State, useState } from "haunted";
 
 let state = new State(() => {
   update();
@@ -505,7 +560,7 @@ function update() {
   state.run(() => {
     const [count, setCount] = useState(0);
 
-    console.log('count is', count);
+    console.log("count is", count);
 
     setTimeout(() => setCount(count + 1), 3000);
   });
@@ -519,8 +574,8 @@ The above will result in the count being incremented every 3 seconds and the cur
 A more practical example is integration with a custom element base class. Here's a simple integration with [LitElement](https://lit-element.polymer-project.org/):
 
 ```js
-import { LitElement } from 'lit-element';
-import { State } from 'haunted';
+import { LitElement } from "lit-element";
+import { State } from "haunted";
 
 export default class LitHauntedElement extends LitElement {
   constructor() {
@@ -547,14 +602,15 @@ More example integrations can be found in [this gist](https://gist.github.com/ma
 
 `component(renderer, options): Element`
 `component(renderer, BaseElement, options): Element`
-- renderer = ``` (element) => html`...` ```  
+
+- renderer = `` (element) => html`...` ``
 - BaseElement = `HTMLElement`
 - options = `{baseElement: HTMLElement, observedAttributes: [], useShadowDOM: true}`
 
 `virtual(renderer): directive`
-- renderer = ``` (element) => html`...` ```  
+
+- renderer = `` (element) => html`...` ``
 
 ## License
 
 BSD-2-Clause
-

--- a/readme.md
+++ b/readme.md
@@ -335,80 +335,58 @@ Most of time, it is preferable to use `useEffect` to avoid blocking visual updat
 
 Create state that updates after being ran through a reducer function.
 
-```html
-<my-counter></my-counter>
+```js
+const initialState = { count: 0 };
 
-<script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
-  import { component, useReducer } from 'https://unpkg.com/haunted/haunted.js';
-
-  const initialState = { count: 0 };
-
-  function reducer(state, action) {
-    switch (action.type) {
-      case 'reset':
-        return initialState;
-      case 'increment':
-        return { count: state.count + 1 };
-      case 'decrement':
-        return { count: state.count - 1 };
-    }
+function reducer(state, action) {
+  switch (action.type) {
+    case 'reset':
+      return initialState;
+    case 'increment':
+      return { count: state.count + 1 };
+    case 'decrement':
+      return { count: state.count - 1 };
   }
+}
 
-  function Counter() {
-    const [state, dispatch] = useReducer(reducer, initialState);
+function Counter() {
+  const [state, dispatch] = useReducer(reducer, initialState);
 
-    return html`
-      Count: ${state.count}
-      <button @click=${() => dispatch({ type: 'reset' })}>
-        Reset
-      </button>
-      <button @click=${() => dispatch({ type: 'increment' })}>+</button>
-      <button @click=${() => dispatch({ type: 'decrement' })}>-</button>
-    `;
-  }
-
-  customElements.define('my-counter', component(Counter));
-</script>
+  return html`
+    Count: ${state.count}
+    <button @click=${() => dispatch({ type: 'reset' })}>
+      Reset
+    </button>
+    <button @click=${() => dispatch({ type: 'increment' })}>+</button>
+    <button @click=${() => dispatch({ type: 'decrement' })}>-</button>
+  `;
+}
 ```
 
 #### useMemo
 
 Create a memoized state value. Only reruns the function when dependent values have changed.
 
-```html
-<my-app></my-app>
+```js
+function fibonacci(num) {
+  if (num <= 1) return 1;
+  return fibonacci(num - 1) + fibonacci(num - 2);
+}
 
-<script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
-  import {
-    component,
-    useMemo,
-    useState
-  } from 'https://unpkg.com/haunted/haunted.js';
+function App() {
+  const [value, setVal] = useState(12);
+  const fib = useMemo(() => fibonacci(value), [value]);
 
-  function fibonacci(num) {
-    if (num <= 1) return 1;
-    return fibonacci(num - 1) + fibonacci(num - 2);
-  }
-
-  function App() {
-    const [value, setVal] = useState(12);
-    const fib = useMemo(() => fibonacci(value), [value]);
-
-    return html`
-      <h1>Fibonacci</h1>
-      <input
-        type="text"
-        @change=${event => setVal(parseInt(event.target.value, 10))}
-        value=${value}
-      />
-      <div>Fibonacci <strong>${fib}</strong></div>
-    `;
-  }
-
-  customElements.define('my-app', component(App));
-</script>
+  return html`
+    <h1>Fibonacci</h1>
+    <input
+      type="text"
+      @change=${event => setVal(parseInt(event.target.value, 10))}
+      value=${value}
+    />
+    <div>Fibonacci <strong>${fib}</strong></div>
+  `;
+}
 ```
 
 #### useRef
@@ -417,20 +395,11 @@ Creates and returns a mutable object (a 'ref') whose `.current` property is init
 
 This differs from `useState` in that state is immutable and can only be changed via `setState` which **will** cause a rerender. That rerender will allow you to be able to see the updated `state` value. A ref, on the other hand, can only be changed via `.current` and since changes to it are mutations, no rerender is required to view the updated value in your component's code (e.g. listeners, callbacks, effects).
 
-```html
-<my-app></my-app>
-
-<script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
-  import { component, useRef } from 'https://unpkg.com/haunted/haunted.js';
-
-  function App() {
-    const myRef = useRef(0);
-    return html`${myRef.current}`;
-  }
-
-  customElements.define('my-app', component(App));
-</script>
+```js
+function App() {
+  const myRef = useRef(0);
+  return html`${myRef.current}`;
+}
 ```
 
 #### useContext
@@ -439,55 +408,42 @@ Grabs the context value from the closest provider above and updates your compone
 
 `useContext` currently only works with custom element components, [track the issue here](https://github.com/matthewp/haunted/issues/40).
 
-```html
-<my-app></my-app>
+```js
+const ThemeContext = createContext('dark');
 
-<script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
-  import {
-    component,
-    createContext,
-    useContext
-  } from 'https://unpkg.com/haunted/haunted.js';
+customElements.define('theme-provider', ThemeContext.Provider);
+customElements.define('theme-consumer', ThemeContext.Consumer);
 
-  const ThemeContext = createContext('dark');
+function Consumer() {
+  const context = useContext(ThemeContext);
+  return context;
+}
 
-  customElements.define('theme-provider', ThemeContext.Provider);
-  customElements.define('theme-consumer', ThemeContext.Consumer);
+customElements.define('my-consumer', component(Consumer));
 
-  function Consumer() {
-    const context = useContext(ThemeContext);
-    return context;
-  }
+function App() {
+  const [theme, setTheme] = useState("light");
 
-  customElements.define('my-consumer', component(Consumer));
+  return html`
+    <select value=${theme} @change=${event => setTheme(event.target.value)}>
+      <option value="dark">Dark</option>
+      <option value="light">Light</option>
+    </select>
 
-  function App() {
-    const [theme, setTheme] = useState("light");
+    <theme-provider .value=${theme}>
+      <my-consumer></my-consumer>
 
-    return html`
-      <select value=${theme} @change=${event => setTheme(event.target.value)}>
-        <option value="dark">Dark</option>
-        <option value="light">Light</option>
-      </select>
-
-      <theme-provider .value=${theme}>
-        <my-consumer></my-consumer>
-
-        <!-- creates context with inverted theme -->
-        <theme-provider .value=${theme === 'dark' ? 'light' : 'dark'}>
-          <theme-consumer
-            .render=${value =>
-              html`<h1>${value}</h1>`
-            }
-          ></theme-consumer>
-        </theme-provider>
+      <!-- creates context with inverted theme -->
+      <theme-provider .value=${theme === 'dark' ? 'light' : 'dark'}>
+        <theme-consumer
+          .render=${value =>
+            html`<h1>${value}</h1>`
+          }
+        ></theme-consumer>
       </theme-provider>
-    `;
-  }
-
-  customElements.define('my-app', component(App));
-</script>
+    </theme-provider>
+  `;
+}
 ```
 
 #### Write Your Own Hook

--- a/readme.md
+++ b/readme.md
@@ -10,8 +10,8 @@ React's Hooks API but for standard web components and [lit-html](https://lit-htm
   <my-counter></my-counter>
 
   <script type="module">
-    import { html } from "https://unpkg.com/lit-html/lit-html.js";
-    import { component, useState } from "https://unpkg.com/haunted/haunted.js";
+    import { html } from 'https://unpkg.com/lit-html/lit-html.js';
+    import { component, useState } from 'https://unpkg.com/haunted/haunted.js';
 
     function Counter() {
       const [count, setCount] = useState(0);
@@ -24,7 +24,7 @@ React's Hooks API but for standard web components and [lit-html](https://lit-htm
       `;
     }
 
-    customElements.define("my-counter", component(Counter));
+    customElements.define('my-counter', component(Counter));
   </script>
 </html>
 ```
@@ -61,7 +61,17 @@ component(MyComponent, { useShadowDOM: false }));
 **Haunted** can be imported just like any other library when using a bundler of your choice:
 
 ```js
-import { component, html, useState } from "haunted";
+import {
+  html,
+  component,
+  useState,
+  useMemo,
+  useEffect,
+  useLayoutEffect,
+  useReducer,
+  useRef,
+  useContext
+} from 'haunted';
 ```
 
 The main entry point is intended for [lit-html](https://github.com/Polymer/lit-html) users.
@@ -71,8 +81,8 @@ The main entry point is intended for [lit-html](https://github.com/Polymer/lit-h
 If you are using [lighterhtml](https://github.com/WebReflection/lighterhtml) or [hyperHTML](https://github.com/WebReflection/hyperHTML) then instead import `haunted/core`. This export gives you a function that creates Hooks that work with any template library.
 
 ```js
-import haunted, { useState } from "haunted/core";
-import { html, render } from "lighterhtml";
+import haunted, { useState } from 'haunted/core';
+import { html, render } from 'lighterhtml';
 
 const { component } = haunted({
   render(what, where) {
@@ -85,7 +95,7 @@ function App() {
   return html`Using lighterhtml! Count: ${count}`;
 }
 
-customElements.define("my-app", component(App));
+customElements.define('my-app', component(App));
 ```
 
 #### Web modules
@@ -93,18 +103,14 @@ customElements.define("my-app", component(App));
 **Haunted** can work directly in the browser without using any build tools. Simply import the `haunted.js` bundle. You can use the [unpkg] or [pika](https://www.pika.dev/cdn) CDNs. This works great for demo pages and small apps. Here's an example with unpkg:
 
 ```js
-import { html } from "https://unpkg.com/lit-html/lit-html.js";
-import {
-  component,
-  useState,
-  useEffect
-} from "https://unpkg.com/haunted/haunted.js";
+import { html } from 'https://unpkg.com/lit-html/lit-html.js';
+import { component, useState } from 'https://unpkg.com/haunted/haunted.js';
 ```
 
 If using pika then use the `html` export from Haunted, as pika bundles everything together:
 
 ```js
-import { useState, component, html } from "https://cdn.pika.dev/haunted";
+import { html, component, useState } from 'https://cdn.pika.dev/haunted';
 ```
 
 If you install Haunted **locally** this build is located at `node_modules/haunted/haunted.js`.
@@ -128,7 +134,7 @@ function App({ name }) {
   return html`Hello ${name}`;
 }
 
-customElements.define("my-app", component(App));
+customElements.define('my-app', component(App));
 ```
 
 You can now use `<my-app></my-app>` anywhere you use HTML (directly in a `.html` file, in JSX, in lit-html templates, wherever).
@@ -141,7 +147,7 @@ There's no way to use the `this` keyword to refer to the instance of your web co
 
 ```js
 const App = ({ name }) => {
-  console.log(this); // => "undefined"
+  console.log(this); // => 'undefined'
   return html`Hello ${name}!`;
 };
 ```
@@ -153,7 +159,7 @@ Now that we have access to `<my-app>` in all HTML, what if you want to render it
 In this instance, we're using lit-html which comes with a `render` function. You can utilize it by passing in your HTML template and the element you wish to render the template into:
 
 ```js
-import { render, html } from "lit-html";
+import { render, html } from 'lit-html';
 
 render(
   html`<my-app name="world"></my-app>`,
@@ -170,15 +176,15 @@ function App({ name }) {
   return `Hello ${name}!`;
 }
 
-App.observedAttributes = ["name"];
+App.observedAttributes = ['name'];
 
-customElements.define("my-app", component(App));
+customElements.define('my-app', component(App));
 ```
 
 Alternatively, you can pass `observedAttributes` as an option to `component()`:
 
 ```js
-component(App, { observedAttributes: ["name"] });
+component(App, { observedAttributes: ['name'] });
 ```
 
 Once your custom element is defined you can then pass in attributes as you would with any other HTML element.
@@ -194,9 +200,6 @@ Haunted also has the concept of _virtual components_. These are components that 
 The following is an example of using virtual components:
 
 ```js
-import { useState, virtual, component } from "haunted";
-import { html, render } from "lit-html";
-
 const Counter = virtual(() => {
   const [count, setCount] = useState(0);
 
@@ -215,8 +218,6 @@ function App() {
     </main>
   `;
 }
-
-customElements.define("my-app", component(App));
 ```
 
 Notice that we have `Counter`, a virtual component, and `App`, a custom element. You can use virtual components within custom elements and custom elements within virtual components.
@@ -257,35 +258,22 @@ const [count, setCount] = useState(() => {
 
 Used to run a side-effect when the component rerenders or when a dependency changes. To run your side-effect only when the component rerenders, only pass in your side-effect function and nothing else:
 
-```html
-<my-counter></my-counter>
+```js
+function Counter() {
+  const [count, setCount] = useState(0);
 
-<script type="module">
-  import { html } from "https://unpkg.com/lit-html/lit-html.js";
-  import {
-    component,
-    useState,
-    useEffect
-  } from "https://unpkg.com/haunted/haunted.js";
+  useEffect(() => {
+    // on every render, a new number will be in the title
+    document.title = `A random number ${Math.random()}`;
+  });
 
-  function Counter() {
-    const [count, setCount] = useState(0);
-
-    useEffect(() => {
-      // on every rerender, a new number will be in the title
-      document.title = `A random number ${Math.random()}`;
-    });
-
-    return html`
-      <div id="count">${count}</div>
-      <button type="button" @click=${() => setCount(count + 1)}>
-        Cause rerender
-      </button>
-    `;
-  }
-
-  customElements.define("my-counter", component(Counter));
-</script>
+  return html`
+    <div id="count">${count}</div>
+    <button type="button" @click=${() => setCount(count + 1)}>
+      Cause rerender
+    </button>
+  `;
+}
 ```
 
 ##### Dependencies
@@ -293,16 +281,12 @@ Used to run a side-effect when the component rerenders or when a dependency chan
 What happens when your code begins to rely on dependencies that can change (state, refs, props)? We no longer want it to rerun on every rerender so we need to ensure that the code we're running, or its result, doesn't become stale. To do this, you should always state all of the dependencies you're using in an array as the second argument to `useEffect`:
 
 ```js
-function App() {
-  const [name, setName] = useState("Dracula");
+const [name, setName] = useState('Dracula');
 
-  useEffect(() => {
-    // This only occurs when `name` changes and on the initial render.
-    document.title = `Hello ${name}`;
-  }, [name]);
-
-  return html`...`;
-}
+useEffect(() => {
+  // This only occurs when `name` changes and on the initial render.
+  document.title = `Hello ${name}`;
+}, [name]);
 ```
 
 A dependency is anything that your side-effect relies on that can change between renders (e.g. state, refs, props). This does not include `setName` or other setters from `useState` because they will never change between renders.
@@ -315,7 +299,7 @@ Here is an example of only running an effect once as opposed to every rerender:
 
 ```js
 useEffect(() => {
-  document.title = "I'll stay like this until someone changes me"
+  document.title = 'I'll stay like this until someone changes me';
 }, []); // note that you must pass the empty array
 ```
 
@@ -326,23 +310,19 @@ Since effects are used for side-effectual things and might run many times in the
 An example of when you might use this is if you are setting up an event listener.
 
 ```js
-function App() {
-  const [name, setName] = useState("Wolf Man");
+const [name, setName] = useState('Wolf Man');
 
-  useEffect(() => {
-    function updateNameFromWorker(event) {
-      setName(event.data);
-    }
+useEffect(() => {
+  function updateNameFromWorker(event) {
+    setName(event.data);
+  }
 
-    worker.addEventListener("message", updateNameFromWorker);
+  worker.addEventListener('message', updateNameFromWorker);
 
-    return () => {
-      worker.removeEventListener("message", updateNameFromWorker);
-    };
-  }, []); // note that it is safe to exclude `setName` from the dependencies because it will never change
-
-  return html`...`;
-}
+  return () => {
+    worker.removeEventListener('message', updateNameFromWorker);
+  };
+}, []); // note that it is safe to exclude `setName` from the dependencies because it will never change
 ```
 
 #### useLayoutEffect
@@ -359,18 +339,18 @@ Create state that updates after being ran through a reducer function.
 <my-counter></my-counter>
 
 <script type="module">
-  import { html } from "https://unpkg.com/lit-html/lit-html.js";
-  import { component, useReducer } from "https://unpkg.com/haunted/haunted.js";
+  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
+  import { component, useReducer } from 'https://unpkg.com/haunted/haunted.js';
 
   const initialState = { count: 0 };
 
   function reducer(state, action) {
     switch (action.type) {
-      case "reset":
+      case 'reset':
         return initialState;
-      case "increment":
+      case 'increment':
         return { count: state.count + 1 };
-      case "decrement":
+      case 'decrement':
         return { count: state.count - 1 };
     }
   }
@@ -380,15 +360,15 @@ Create state that updates after being ran through a reducer function.
 
     return html`
       Count: ${state.count}
-      <button @click=${() => dispatch({ type: "reset" })}>
+      <button @click=${() => dispatch({ type: 'reset' })}>
         Reset
       </button>
-      <button @click=${() => dispatch({ type: "increment" })}>+</button>
-      <button @click=${() => dispatch({ type: "decrement" })}>-</button>
+      <button @click=${() => dispatch({ type: 'increment' })}>+</button>
+      <button @click=${() => dispatch({ type: 'decrement' })}>-</button>
     `;
   }
 
-  customElements.define("my-counter", component(Counter));
+  customElements.define('my-counter', component(Counter));
 </script>
 ```
 
@@ -400,12 +380,12 @@ Create a memoized state value. Only reruns the function when dependent values ha
 <my-app></my-app>
 
 <script type="module">
-  import { html } from "https://unpkg.com/lit-html/lit-html.js";
+  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
   import {
     component,
     useMemo,
     useState
-  } from "https://unpkg.com/haunted/haunted.js";
+  } from 'https://unpkg.com/haunted/haunted.js';
 
   function fibonacci(num) {
     if (num <= 1) return 1;
@@ -427,7 +407,7 @@ Create a memoized state value. Only reruns the function when dependent values ha
     `;
   }
 
-  customElements.define("my-app", component(App));
+  customElements.define('my-app', component(App));
 </script>
 ```
 
@@ -441,15 +421,15 @@ This differs from `useState` in that state is immutable and can only be changed 
 <my-app></my-app>
 
 <script type="module">
-  import { html } from "https://unpkg.com/lit-html/lit-html.js";
-  import { component, useRef } from "https://unpkg.com/haunted/haunted.js";
+  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
+  import { component, useRef } from 'https://unpkg.com/haunted/haunted.js';
 
   function App() {
     const myRef = useRef(0);
     return html`${myRef.current}`;
   }
 
-  customElements.define("my-app", component(App));
+  customElements.define('my-app', component(App));
 </script>
 ```
 
@@ -463,24 +443,24 @@ Grabs the context value from the closest provider above and updates your compone
 <my-app></my-app>
 
 <script type="module">
-  import { html } from "https://unpkg.com/lit-html/lit-html.js";
+  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
   import {
     component,
     createContext,
     useContext
-  } from "https://unpkg.com/haunted/haunted.js";
+  } from 'https://unpkg.com/haunted/haunted.js';
 
-  const ThemeContext = createContext("dark");
+  const ThemeContext = createContext('dark');
 
-  customElements.define("theme-provider", ThemeContext.Provider);
-  customElements.define("theme-consumer", ThemeContext.Consumer);
+  customElements.define('theme-provider', ThemeContext.Provider);
+  customElements.define('theme-consumer', ThemeContext.Consumer);
 
   function Consumer() {
     const context = useContext(ThemeContext);
     return context;
   }
 
-  customElements.define("my-consumer", component(Consumer));
+  customElements.define('my-consumer', component(Consumer));
 
   function App() {
     const [theme, setTheme] = useState("light");
@@ -495,7 +475,7 @@ Grabs the context value from the closest provider above and updates your compone
         <my-consumer></my-consumer>
 
         <!-- creates context with inverted theme -->
-        <theme-provider .value=${theme === "dark" ? "light" : "dark"}>
+        <theme-provider .value=${theme === 'dark' ? 'light' : 'dark'}>
           <theme-consumer
             .render=${value =>
               html`<h1>${value}</h1>`
@@ -506,7 +486,7 @@ Grabs the context value from the closest provider above and updates your compone
     `;
   }
 
-  customElements.define("my-app", component(App));
+  customElements.define('my-app', component(App));
 </script>
 ```
 
@@ -541,7 +521,7 @@ It has a signature of: `new State(update, [ hostElement ])`.
 Here's an example how it can be used to run hooks code:
 
 ```js
-import { State, useState } from "haunted";
+import { State, useState } from 'haunted';
 
 let state = new State(() => {
   update();
@@ -550,7 +530,7 @@ let state = new State(() => {
 function update() {
   state.run(() => {
     const [count, setCount] = useState(0);
-    console.log("count is", count);
+    console.log('count is', count);
 
     setTimeout(() => setCount(count + 1), 3000);
   });
@@ -564,8 +544,8 @@ The above will result in the count being incremented every 3 seconds and the cur
 A more practical example is integration with a custom element base class. Here's a simple integration with [LitElement](https://lit-element.polymer-project.org/):
 
 ```js
-import { LitElement } from "lit-element";
-import { State } from "haunted";
+import { LitElement } from 'lit-element';
+import { State } from 'haunted';
 
 export default class LitHauntedElement extends LitElement {
   constructor() {

--- a/readme.md
+++ b/readme.md
@@ -316,8 +316,8 @@ function App() {
   let [name, setName] = useState("Wolf Man");
 
   useEffect(() => {
-    function updateNameFromWorker(ev) {
-      setName(ev.data);
+    function updateNameFromWorker(event) {
+      setName(event.data);
     }
 
     worker.addEventListener("message", updateNameFromWorker);
@@ -411,7 +411,7 @@ Create a memoized state value. Only reruns the function when dependent values ha
       <h1>Fibonacci</h1>
       <input
         type="text"
-        @change=${ev => setVal(Number(ev.target.value))}
+        @change=${event => setVal(Number(event.target.value))}
         value="${value}"
       />
       <div>Fibonacci <strong>${fib}</strong></div>

--- a/readme.md
+++ b/readme.md
@@ -112,7 +112,7 @@ If using pika then use the `html` export from Haunted, as pika bundles everythin
 import { html, component, useState } from 'https://cdn.pika.dev/haunted';
 ```
 
-If you install Haunted **locally** this build is located at `node_modules/haunted/haunted.js`.
+If you install Haunted **locally** this build is located at `/node_modules/haunted/haunted.js`. And if you're using PikaPkg (@pika/web) then you'll import it from `/web_modules/haunted.js`.
 
 ## API
 

--- a/readme.md
+++ b/readme.md
@@ -399,7 +399,6 @@ Create a memoized state value. Only reruns the function when dependent values ha
 
   function fibonacci(num) {
     if (num <= 1) return 1;
-
     return fibonacci(num - 1) + fibonacci(num - 2);
   }
 
@@ -439,7 +438,6 @@ This differs from `useState` in that state is immutable and can only be changed 
 
   function App() {
     const myRef = useRef(0);
-
     return html`${myRef.current}`;
   }
 

--- a/readme.md
+++ b/readme.md
@@ -216,7 +216,6 @@ function Profile({ userData }) {
 
 customElements.define('my-profile', component(Profile));
 
-
 function App() {
   const userData = useFictitiousUser();
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,6 @@
 React's Hooks API but for standard web components and [lit-html](https://lit-html.polymer-project.org/) or [hyperHTML](https://codepen.io/WebReflection/pen/pxXrdy?editors=0010).
 
 ```html
-<!DOCTYPE html>
 <html lang="en">
   <my-counter></my-counter>
 
@@ -257,8 +256,6 @@ const [count, setCount] = useState(() => {
 Useful for side-effects that run after the render has been commited.
 
 ```html
-<!DOCTYPE html>
-
 <my-counter></my-counter>
 
 <script type="module">
@@ -342,8 +339,6 @@ Most of time, it is preferable to use `useEffect` to avoid blocking visual updat
 Create state that updates after being ran through a reducer function.
 
 ```html
-<!DOCTYPE html>
-
 <my-counter></my-counter>
 
 <script type="module">
@@ -385,8 +380,6 @@ Create state that updates after being ran through a reducer function.
 Create a memoized state value. Only reruns the function when dependent values have changed.
 
 ```html
-<!DOCTYPE html>
-
 <my-app></my-app>
 
 <script type="module">
@@ -428,8 +421,6 @@ Creates and returns a mutable object (a 'ref') whose `.current` property is init
 This differs from `useState` in that state is immutable and can only be changed via `setState` which **will** cause a rerender. That rerender will allow you to be able to see the updated `state` value. A ref, on the other hand, can only be changed via `.current` and since changes to it are mutations, no rerender is required to view the updated value in your component's code (e.g. listeners, callbacks, effects).
 
 ```html
-<!DOCTYPE html>
-
 <my-app></my-app>
 
 <script type="module">
@@ -447,12 +438,11 @@ This differs from `useState` in that state is immutable and can only be changed 
 
 #### useContext
 
-Grabs context value from the closest provider up in the tree and updates component when value of a provider changes.
-Limited only to "real" components for now.
+Grabs the context value from the closest provider above and updates your component, the consumer, whenever the provider changes the value.
+
+`useContext` currently only works with custom element components, [track the issue here](https://github.com/matthewp/haunted/issues/40).
 
 ```html
-<!DOCTYPE html>
-
 <my-app></my-app>
 
 <script type="module">

--- a/readme.md
+++ b/readme.md
@@ -265,7 +265,23 @@ customElements.define('store-product', component(Product));
 With this, you can now listen for the `buy-product` event either on an instance of `<store-product>` itself or higher up in the DOM. Here are examples of both of these instances:
 
 ```js
-/* Example of listening higher up in the DOM */
+/* Example of listening on an element (can be <store-product> or anything above it) */
+function Store() {
+  return html`
+    <store-product
+      name="T-Shirt"
+      price="10.00"
+      product-id="0001"
+      @buy-product=${event => {
+        console.log('We can listen to the event on <store-product> itself 🙂')
+      }}
+    ></store-product>
+  `;
+}
+
+customElements.define('my-store', component(Store));
+
+/* Example of listening higher up in the DOM on `this` */
 function App() {
   useEffect(() => {
     const handleReportProduct = event => {
@@ -280,22 +296,8 @@ function App() {
     }
   }, []); // make sure you list all dependencies
 
-  return html`${Store()}`;
+  return html`<my-store></my-store>`;
 }
-
-/* Example of listening on an element (can be <store-product> or anything above it) */
-const Store = virtual(() => {
-  return html`
-    <store-product
-      name="T-Shirt"
-      price="10.00"
-      product-id="0001"
-      @buy-product=${event => {
-        console.log('We can also listen to the event on the custom element itself 🙂')
-      }}
-    ></store-product>
-  `;
-})
 ```
 
 If you want to look more into firing events, here are some links:

--- a/readme.md
+++ b/readme.md
@@ -574,13 +574,16 @@ Most functionality can be achieved with the provided hooks above, but you can al
 import { hook, Hook } from 'haunted';
 
 const useMyHook = hook(class extends Hook {
-  constructor(id, state) {
+  // everything after `state` is an argument passed to your hook
+  constructor(id, state, your, hooks, args) {
     super(id, state);
-    // ...
+    // you can trigger an update by calling `this.state.update()`
   }
 
-  update() { /* ... */ }
-  teardown() { /* ... */ }
+  update(your, hooks, args) {
+    return ['the value returned from', your, 'hook'];
+  }
+  teardown() { /* called when the hook is to be torn down */ }
 });
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,7 @@ customElements.define('my-app', component(App));
 
 #### Web modules
 
-**Haunted** can work directly in the browser without using any build tools. Simply import the `haunted.js` bundle. You can use the [unpkg] or [pika](https://www.pika.dev/cdn) CDNs. This works great for demo pages and small apps. Here's an example with unpkg:
+**Haunted** can work directly in the browser without using any build tools. Simply import the `haunted.js` bundle. You can use the [unpkg](https://unpkg.com/) or [pika](https://www.pika.dev/cdn) CDNs. This works great for demo pages and small apps. Here's an example with unpkg:
 
 ```js
 import { html } from 'https://unpkg.com/lit-html/lit-html.js';

--- a/readme.md
+++ b/readme.md
@@ -194,7 +194,7 @@ Once your custom element is defined you can then pass in attributes as you would
 
 #### Virtual components
 
-Haunted also has the concept of _virtual components_. These are components that are not defined as a tag. Rather they are functions that can be called from within another template. They have their own state and will rerender when that state changes, _without_ causing any parent components to rerender.
+Haunted also has the concept of _virtual components_. These are components that are not defined as a tag. Instead they're defined as functions that can be called from within another template. They have their own state and will rerender when that state changes _without_ causing any parent components to rerender.
 
 The following is an example of using virtual components:
 
@@ -227,7 +227,7 @@ If you wanted you could create an entire app of virtual components.
 
 ##### Virtual components and `this`
 
-You'll notice that in the above examples, we're using the fat arrow syntax. This is due to virtual components not being attached to any actual custom elements, therefore, `this` never points to anything negating the purpose of using the function syntax.
+You'll notice that in the above examples, we're using the fat arrow syntax. This is due to virtual components not being attached to any actual custom elements, therefore, `this` never points to anything which negates the purpose of using the function syntax.
 
 ### Hooks
 

--- a/readme.md
+++ b/readme.md
@@ -480,7 +480,7 @@ Limited only to "real" components for now.
     const [theme, setTheme] = useState("light");
 
     return html`
-      <select value=${theme} @change=${e => setTheme(e.target.value)}>
+      <select value=${theme} @change=${event => setTheme(event.target.value)}>
         <option value="dark">Dark</option>
         <option value="light">Light</option>
       </select>
@@ -514,13 +514,11 @@ import { hook, Hook } from 'haunted';
 const useMyHook = hook(class extends Hook {
   constructor(id, state) {
     super(id, state);
-    ...
+    // ...
   }
 
   update() { ... }
-
   teardown() { ... }
-
 });
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -217,6 +217,8 @@ function App() {
     </main>
   `;
 }
+
+customElements.define('my-app', component(App));
 ```
 
 Notice that we have `Counter`, a virtual component, and `App`, a custom element. You can use virtual components within custom elements and custom elements within virtual components.

--- a/readme.md
+++ b/readme.md
@@ -39,17 +39,13 @@ A starter app is available on [codesandbox](https://codesandbox.io/s/github/matt
 npm install haunted
 ```
 
-For Internet Explorer 11, you'll need to use a proxy polyfill, in addition to the usual webcomponentsjs polyfills.
-
-eg.
+For Internet Explorer 11, you'll need to use a proxy polyfill to use Haunted, in addition to the usual webcomponentsjs polyfills.
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/proxy-polyfill@0.3.0/proxy.min.js"></script>
 ```
 
-Here is a full example of Haunted with Internet Explorer 11: https://github.com/crisward/haunted-ie11
-
-You can also use Custom Elements without the Shadow DOM if you need to:
+Here is a [full example of a web app that uses Haunted built for Internet Explorer 11](https://github.com/crisward/haunted-ie11). You can also use Custom Elements without the Shadow DOM if you need to:
 
 ```js
 component(MyComponent, { useShadowDOM: false }));

--- a/readme.md
+++ b/readme.md
@@ -186,11 +186,47 @@ Alternatively, you can pass `observedAttributes` as an option to `component()`:
 component(App, { observedAttributes: ['name'] });
 ```
 
-Once your custom element is defined you can then pass in attributes as you would with any other HTML element.
+Once your custom element is defined you can then pass in attributes as you would with any other HTML element. Just like any other HTML attribute **only strings are accepted**, anything else will be converted into a string.
 
 ```html
 <my-app name="World"></my-app>
 ```
+
+##### Properties
+
+If you haven't used lit-html before you're probably wondering what the differences between properties and attributes are. As stated above, attributes can only have string values, this is because all attributes go through [`Element#setAttribute`](https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute). Properties do not go through `setAttribute`, instead they are properties on the custom element itself. This allows you to pass in any value instead of just strings.
+
+To bind to a property in lit-html, you can use the `.` prefix before the property name:
+
+```js
+function Profile({ userData }) {
+  return html`
+    <section>
+      <h2>Profile</h2>
+      <article>
+        <figure>
+          <img src=${userData.portrait} alt="user portait" />
+          <figcaption>${userData.name}</figcaption>
+        </figure>
+        <p>${userData.bio}</p>
+      </article>
+    </section>
+  `;
+}
+
+customElements.define('my-profile', component(Profile));
+
+
+function App() {
+  const userData = useFictitiousUser();
+
+  return html`
+    <my-profile .userData=${userData}></my-profile>
+  `;
+}
+```
+
+Notice that it is encouraged to use camel case here instead of kebab case as these aren't attributes, they're properties that you'll most likely be using as variables at some point.
 
 ##### Dispatching Events
 

--- a/readme.md
+++ b/readme.md
@@ -237,17 +237,19 @@ Currently Haunted supports the following hooks:
 
 #### useState
 
-Create a tuple of state and a function to change that state.
+Returns a tuple of two values. The first value is the immutable state that is initialized to the argument you pass in. The second value is the function that is used to change the first value (the setter).
+
+When the setter is called, the element in which the state resides is rerendered.
 
 ```js
 const [count, setCount] = useState(0);
 ```
 
-Additionally you can provide a function as the argument to useState, in which case the function is called to initialize the first state, but never called again.
+Additionally if you provide a function as the argument to `useState`, the function is called to initialize the first state, but never called again.
 
 ```js
 const [count, setCount] = useState(() => {
-  return expensiveFunction();
+  return expensiveComputation(42);
 });
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -223,7 +223,7 @@ customElements.define('my-app', component(App));
 
 Notice that we have `Counter`, a virtual component, and `App`, a custom element. You can use virtual components within custom elements and custom elements within virtual components.
 
-The only difference is that custom elements are used by using their tag name (e.g. `<my-app>`) and virtual components are called as functions.
+The only difference is that custom elements are utilized via their tag name (e.g. `<my-app>`) and virtual components are called as functions (e.g. `${Counter()}`).
 
 If you wanted you could create an entire app of virtual components.
 

--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,9 @@ const { component } = haunted({
 
 function App() {
   const [count, setCount] = useState(0);
-  return html`Using lighterhtml! Count: ${count}`;
+  return html`
+    Using lighterhtml! Count: ${count}
+  `;
 }
 
 customElements.define("my-app", component(App));
@@ -126,7 +128,9 @@ A Custom Element can be defined via haunted by passing your custom component you
 
 ```js
 function App({ name }) {
-  return html`Hello ${name}`;
+  return html`
+    Hello ${name}
+  `;
 }
 
 customElements.define("my-app", component(App));
@@ -143,7 +147,9 @@ There's no way to use the `this` keyword to refer to the instance of your web co
 ```js
 const App = ({ name }) => {
   console.log(this); // => "undefined"
-  return html`Hello ${name}!`;
+  return html`
+    Hello ${name}!
+  `;
 };
 ```
 
@@ -157,7 +163,9 @@ In this instance, we're using lit-html which comes with a `render` function. You
 import { render, html } from "lit-html";
 
 render(
-  html`<my-app name="world"></my-app>`,
+  html`
+    <my-app name="world"></my-app>
+  `,
   document.body
 );
 ```
@@ -301,7 +309,9 @@ function App() {
     document.title = `Hello ${name}`;
   }, [name]);
 
-  return html`...`;
+  return html`
+    ...
+  `;
 }
 ```
 
@@ -327,7 +337,9 @@ function App() {
     };
   });
 
-  return html`...`;
+  return html`
+    ...
+  `;
 }
 ```
 
@@ -411,7 +423,7 @@ Create a memoized state value. Only reruns the function when dependent values ha
       <h1>Fibonacci</h1>
       <input
         type="text"
-        @change=${event => setVal(Number(event.target.value))}
+        @change=${event => setVal(parseInt(event.target.value, 10))}
         value="${value}"
       />
       <div>Fibonacci <strong>${fib}</strong></div>
@@ -438,7 +450,9 @@ Create and returns an object with one property "current" which can be assigned a
   function App() {
     const myRef = useRef(0);
 
-    return html`${myRef.current}`;
+    return html`
+      ${myRef.current}
+    `;
   }
 
   customElements.define("my-app", component(App));
@@ -492,8 +506,9 @@ Limited only to "real" components for now.
         <theme-provider .value=${theme === "dark" ? "light" : "dark"}>
           <theme-consumer
             .render=${value =>
-              html`<h1>${value}</h1>`
-            }
+              html`
+                <h1>${value}</h1>
+              `}
           ></theme-consumer>
         </theme-provider>
       </theme-provider>

--- a/readme.md
+++ b/readme.md
@@ -140,7 +140,7 @@ You can now use `<my-app></my-app>` anywhere you use HTML (directly in a `.html`
 
 ##### Brief Digression:
 
-Another way to write your component is with the arrow function syntax, or fat arrow. It offers a more concise and clean way to write your code, however, it does come with a one drawback:
+Another way to write your component is with the arrow function syntax, or fat arrow. It offers a more concise and clean way to write your code, however, it does come with one drawback:
 
 There's no way to use the `this` keyword to refer to the instance of your web component that is running.
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-🦇 🎃
+# Haunted 🦇 🎃
 
 [![npm](https://img.shields.io/npm/dt/haunted)](https://npm.im/haunted)
 [![npm](https://img.shields.io/npm/v/haunted)](https://npm.im/haunted)

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Haunted 🦇 🎃
+ 🦇 🎃
 
 [![npm](https://img.shields.io/npm/dt/haunted)](https://npm.im/haunted)
 [![npm](https://img.shields.io/npm/v/haunted)](https://npm.im/haunted)
@@ -78,10 +78,12 @@ const { component } = haunted({
   }
 });
 
-const App = component(() => {
+function App() {
   const [count, setCount] = useState(0);
   return html`Using lighterhtml! Count: ${count}`;
-});
+}
+
+customElements.define('my-app', component(App));
 ```
 
 #### Web modules
@@ -555,3 +557,4 @@ More example integrations can be found in [this gist](https://gist.github.com/ma
 ## License
 
 BSD-2-Clause
+

--- a/readme.md
+++ b/readme.md
@@ -168,14 +168,14 @@ render(
 
 ##### Attributes
 
-In custom elements, attributes must be pre-defined. To define what attributes your component supports, set the `observedAttributes` property on the function you defined.
+In custom elements, attributes must be pre-defined. To define what attributes your component supports, set the `observedAttributes` property on the function you defined. Note that attributes use kebab case in templates and are converted into camel case for use in your component's code.
 
 ```js
-function App({ name }) {
-  return `Hello ${name}!`;
+function App({ firstName }) {
+  return `Hello ${firstName}!`;
 }
 
-App.observedAttributes = ['name'];
+App.observedAttributes = ['first-name'];
 
 customElements.define('my-app', component(App));
 ```
@@ -183,13 +183,13 @@ customElements.define('my-app', component(App));
 Alternatively, you can pass `observedAttributes` as an option to `component()`:
 
 ```js
-component(App, { observedAttributes: ['name'] });
+component(App, { observedAttributes: ['first-name'] });
 ```
 
 Once your custom element is defined you can then pass in attributes as you would with any other HTML element. Just like any other HTML attribute **only strings are accepted**, anything else will be converted into a string.
 
 ```html
-<my-app name="World"></my-app>
+<my-app first-name="World"></my-app>
 ```
 
 ##### Properties

--- a/readme.md
+++ b/readme.md
@@ -197,7 +197,7 @@ Once your custom element is defined you can then pass in attributes as you would
 There are a few steps you have to take in order to dispatch an event from your custom element:
 
 1. Use the function syntax to define your component. This will give you access to `this`, the instance of your custom element.
-2. When defining your callback that you wish to dispatch from, make sure it is bound to `this`. You can do this by either using the fat arrow syntax or by using the result of `.bind(this)` as your callback.
+2. When defining your callback that you wish to dispatch from, make sure it is bound to `this`. You can do this by using the fat arrow syntax.
 3. Finally, you can create a `new CustomEvent` and pass that to `this.dispatchEvent`.
 
 Here are a couple of examples of dispatching events from a haunted custom element:
@@ -213,24 +213,11 @@ function Product({ name, price, productId }) {
     this.dispatchEvent(event);
   }
 
-  function reportProduct() {
-    const reason = window.prompt('Why are you reporting this product?');
-    const event = new CustomEvent('report-product', {
-      bubbles: true,
-      composed: true,
-      detail: { productId, reason }
-    });
-    this.dispatchEvent(event);
-  }
-
   return html`
     <article>
       <h3>${name}</h3>
       <p>Price: ${price} USD</p>
-
       <button @click=${buyProduct}>Purchase</button>
-      <!-- `reportProduct` must be bound to `this` before use -->
-      <button @click=${reportProduct.bind(this)}>Report</button>
     </article>
   `;
 }
@@ -240,9 +227,10 @@ Product.observedAttributes = ['name', 'price', 'product-id'];
 customElements.define('store-product', component(Product));
 ```
 
-With this, you can now listen for these events either on an instance of `<store-product>` itself or higher up in the DOM. Here are examples of both of these instances:
+With this, you can now listen for the `buy-product` event either on an instance of `<store-product>` itself or higher up in the DOM. Here are examples of both of these instances:
 
 ```js
+/* Example of listening higher up in the DOM */
 function App() {
   useEffect(() => {
     const handleReportProduct = event => {
@@ -257,6 +245,11 @@ function App() {
     }
   }, []); // make sure you list all dependencies
 
+  return html`${Store()}`;
+}
+
+/* Example of listening on an element (can be <store-product> or anything above it) */
+const Store = virtual(() => {
   return html`
     <store-product
       name="T-Shirt"
@@ -267,7 +260,7 @@ function App() {
       }}
     ></store-product>
   `;
-}
+})
 ```
 
 If you want to look more into firing events, here are some links:

--- a/readme.md
+++ b/readme.md
@@ -333,7 +333,7 @@ function App() {
 
 #### useLayoutEffect
 
-The function signature is the same as `useEffect`, but the callback is being called synchronously after rendering. Updates scheduled inside `useLayoutEffect` will therefore be flushed synchronously, before the browser has a chance to paint.
+The function signature is the same as `useEffect`, but the callback is being called synchronously after rendering. Therefore, updates scheduled inside `useLayoutEffect` will be flushed synchronously before the browser has a chance to paint.
 
 Most of time, it is preferable to use `useEffect` to avoid blocking visual updates.
 

--- a/readme.md
+++ b/readme.md
@@ -47,10 +47,9 @@ eg.
 <script src="https://cdn.jsdelivr.net/npm/proxy-polyfill@0.3.0/proxy.min.js"></script>
 ```
 
-For a full example with Internet Explorer 11, see - https://github.com/crisward/haunted-ie11
+Here is a full example of Haunted with Internet Explorer 11: https://github.com/crisward/haunted-ie11
 
-You can also use Custom Elements without Shadow DOM if you wish.
-eg.
+You can also use Custom Elements without the Shadow DOM if you need to:
 
 ```js
 component(MyComponent, { useShadowDOM: false }));

--- a/readme.md
+++ b/readme.md
@@ -83,9 +83,7 @@ const { component } = haunted({
 
 function App() {
   const [count, setCount] = useState(0);
-  return html`
-    Using lighterhtml! Count: ${count}
-  `;
+  return html`Using lighterhtml! Count: ${count}`;
 }
 
 customElements.define("my-app", component(App));
@@ -128,9 +126,7 @@ A Custom Element can be defined via haunted by passing your custom component you
 
 ```js
 function App({ name }) {
-  return html`
-    Hello ${name}
-  `;
+  return html`Hello ${name}`;
 }
 
 customElements.define("my-app", component(App));
@@ -147,9 +143,7 @@ There's no way to use the `this` keyword to refer to the instance of your web co
 ```js
 const App = ({ name }) => {
   console.log(this); // => "undefined"
-  return html`
-    Hello ${name}!
-  `;
+  return html`Hello ${name}!`;
 };
 ```
 
@@ -163,9 +157,7 @@ In this instance, we're using lit-html which comes with a `render` function. You
 import { render, html } from "lit-html";
 
 render(
-  html`
-    <my-app name="world"></my-app>
-  `,
+  html`<my-app name="world"></my-app>`,
   document.body
 );
 ```
@@ -309,9 +301,7 @@ function App() {
     document.title = `Hello ${name}`;
   }, [name]);
 
-  return html`
-    ...
-  `;
+  return html`...`;
 }
 ```
 
@@ -337,9 +327,7 @@ function App() {
     };
   });
 
-  return html`
-    ...
-  `;
+  return html`...`;
 }
 ```
 
@@ -424,7 +412,7 @@ Create a memoized state value. Only reruns the function when dependent values ha
       <input
         type="text"
         @change=${event => setVal(parseInt(event.target.value, 10))}
-        value="${value}"
+        value=${value}
       />
       <div>Fibonacci <strong>${fib}</strong></div>
     `;
@@ -450,9 +438,7 @@ Create and returns an object with one property "current" which can be assigned a
   function App() {
     const myRef = useRef(0);
 
-    return html`
-      ${myRef.current}
-    `;
+    return html`${myRef.current}`;
   }
 
   customElements.define("my-app", component(App));
@@ -506,9 +492,8 @@ Limited only to "real" components for now.
         <theme-provider .value=${theme === "dark" ? "light" : "dark"}>
           <theme-consumer
             .render=${value =>
-              html`
-                <h1>${value}</h1>
-              `}
+              html`<h1>${value}</h1>`
+            }
           ></theme-consumer>
         </theme-provider>
       </theme-provider>

--- a/readme.md
+++ b/readme.md
@@ -172,31 +172,28 @@ render(
 
 ##### Attributes
 
-In custom elements, attributes must be pre-defined. Properties, on the other hand, do not. To define what attributes your component supports, set the `observedAttributes` property on the functional component. For example:
+In custom elements, attributes must be pre-defined. To define what attributes your component supports, set the `observedAttributes` property on the function you defined.
 
 ```js
-const App = ({ name }) => {
+function App({ name }) {
   return `Hello ${name}!`;
-};
+}
 
 App.observedAttributes = ["name"];
 
-customElements.define("hello-app", component(App));
+customElements.define("my-app", component(App));
 ```
 
 Alternatively, you can pass `observedAttributes` as an option to `component()`:
 
 ```js
-customElements.define(
-  "hello-app",
-  component(App, { observedAttributes: ["name"] })
-);
+component(App, { observedAttributes: ["name"] });
 ```
 
-Which allows you to author (in HTML):
+Once your custom element is defined you can then pass in attributes as you would with any other HTML element.
 
 ```html
-<hello-app name="world"></hello-app>
+<my-app name="World"></my-app>
 ```
 
 #### Virtual components

--- a/readme.md
+++ b/readme.md
@@ -470,7 +470,6 @@ Limited only to "real" components for now.
 
   function Consumer() {
     const context = useContext(ThemeContext);
-
     return context;
   }
 
@@ -517,8 +516,8 @@ const useMyHook = hook(class extends Hook {
     // ...
   }
 
-  update() { ... }
-  teardown() { ... }
+  update() { /* ... */ }
+  teardown() { /* ... */ }
 });
 ```
 
@@ -544,7 +543,6 @@ let state = new State(() => {
 function update() {
   state.run(() => {
     const [count, setCount] = useState(0);
-
     console.log("count is", count);
 
     setTimeout(() => setCount(count + 1), 3000);
@@ -565,7 +563,6 @@ import { State } from "haunted";
 export default class LitHauntedElement extends LitElement {
   constructor() {
     super();
-
     this.hauntedState = new State(() => this.requestUpdate(), this);
   }
 

--- a/readme.md
+++ b/readme.md
@@ -300,7 +300,7 @@ Here is an example of only running an effect once as opposed to every rerender:
 
 ```js
 useEffect(() => {
-  document.title = 'I'll stay like this until someone changes me';
+  document.title = 'I will stay like this until someone changes me';
 }, []); // note that you must pass the empty array
 ```
 


### PR DESCRIPTION
Fixes #150
Fixes #151

Changelog:

- Fixed grammar
- Touched up wording everywhere
- Made the list of imports for import example longer
- Reformatted components to use the `function` syntax as discussed in #151
  - Added an explanation as to why this syntax should be used
- Removed the irrelevant parts of examples (boilerplate, obvious imports)
- Elaborated in some examples to give a more detailed understanding of what's going on
- Added a section on using properties as they were only mentioned once before and in a confusing manner.
- Added a section on dispatching events as discussed in #150
- Added a small subsection explaining why virtual components don't have access to `this` and why fat arrow syntax is encouraged when writing virtual components
- Added a section explaining dependencies and how they work with `useEffect`
- Added a section for `useCallback`
- Now using an empty array for `useEffect` dependencies in "Cleaning up side-effects" example to avoid rerunning the side-effect and it's clean up on every rerender
- Now using `parseInt` instead of `Number` in example
- Explained how and when to run a side-effect on "mount"
- Code formatting

If there's anything in here that looks like it needs to be changed/fixed let me know 👍 
Thank you for your time.