### PR TITLE
Fix skipped effects

### DIFF
--- a/src/create-effect.ts
+++ b/src/create-effect.ts
@@ -19,6 +19,7 @@ function createEffect(setEffects: (state: State, cb: Callable) => void) {
       this.callback = callback;
       this.lastValues = this.values;
       this.values = values;
+      console.log(this.state.host, 'effect update', {lastValues: this.lastValues, values: this.values})
     }
 
     call(): void {
@@ -28,6 +29,7 @@ function createEffect(setEffects: (state: State, cb: Callable) => void) {
     }
 
     run(): void {
+      console.log(this.state.host, 'effect run')
       this.teardown();
       this._teardown = this.callback.call(this.state);
     }

--- a/src/create-effect.ts
+++ b/src/create-effect.ts
@@ -19,7 +19,6 @@ function createEffect(setEffects: (state: State, cb: Callable) => void) {
       this.callback = callback;
       this.lastValues = this.values;
       this.values = values;
-      console.log(this.state.host, 'effect update', {lastValues: this.lastValues, values: this.values})
     }
 
     call(): void {
@@ -29,7 +28,6 @@ function createEffect(setEffects: (state: State, cb: Callable) => void) {
     }
 
     run(): void {
-      console.log(this.state.host, 'effect run')
       this.teardown();
       this._teardown = this.callback.call(this.state);
     }

--- a/src/create-effect.ts
+++ b/src/create-effect.ts
@@ -17,7 +17,6 @@ function createEffect(setEffects: (state: State, cb: Callable) => void) {
 
     update(callback: Effect, values?: unknown[]): void {
       this.callback = callback;
-      this.lastValues = this.values;
       this.values = values;
     }
 
@@ -25,6 +24,7 @@ function createEffect(setEffects: (state: State, cb: Callable) => void) {
       if(!this.values || this.hasChanged()) {
         this.run();
       }
+      this.lastValues = this.values;
     }
 
     run(): void {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -46,23 +46,16 @@ abstract class BaseScheduler<R extends GenericRenderer, H> {
   update(): void {
     if(this._updateQueued) return;
     read(() => {
-      console.log(this.host, 'handle update')
       let result = this.handlePhase(updateSymbol);
       write(() => {
-        console.log(this.host, 'handle commit')
         this.handlePhase(commitSymbol, result);
 
         write(() => {
-          console.log(this.host, 'handle effects')
           this.handlePhase(effectsSymbol);
-          console.log(this.host, 'done')
         });
-        console.log(this.host, 'effects queued')
       });
-      console.log(this.host, 'commit queued')
       this._updateQueued = false;
     });
-    console.log(this.host, 'update queued')
     this._updateQueued = true;
   }
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -46,16 +46,23 @@ abstract class BaseScheduler<R extends GenericRenderer, H> {
   update(): void {
     if(this._updateQueued) return;
     read(() => {
+      console.log(this.host, 'handle update')
       let result = this.handlePhase(updateSymbol);
       write(() => {
+        console.log(this.host, 'handle commit')
         this.handlePhase(commitSymbol, result);
 
         write(() => {
+          console.log(this.host, 'handle effects')
           this.handlePhase(effectsSymbol);
+          console.log(this.host, 'done')
         });
+        console.log(this.host, 'effects queued')
       });
+      console.log(this.host, 'commit queued')
       this._updateQueued = false;
     });
+    console.log(this.host, 'update queued')
     this._updateQueued = true;
   }
 

--- a/test/test-effects.js
+++ b/test/test-effects.js
@@ -168,14 +168,9 @@ describe('useEffect', () => {
     const teardown = attach(parentTag);
     await cycle();
 
-    console.log('start test')
-    console.log('parentSet(1)')
     parentSet(1)
-    console.log('childSet(1)')
     childSet(1)
-    console.log('await cycle()')
     await cycle();
-    console.log('end test')
 
     assert.equal(parentEffects, 2, 'parent effects ran twice');
     assert.equal(childEffects, 2, 'child effects ran twice');

--- a/test/test-effects.js
+++ b/test/test-effects.js
@@ -168,9 +168,14 @@ describe('useEffect', () => {
     const teardown = attach(parentTag);
     await cycle();
 
+    console.log('start test')
+    console.log('parentSet(1)')
     parentSet(1)
+    console.log('childSet(1)')
     childSet(1)
+    console.log('await cycle()')
     await cycle();
+    console.log('end test')
 
     assert.equal(parentEffects, 2, 'parent effects ran twice');
     assert.equal(childEffects, 2, 'child effects ran twice');


### PR DESCRIPTION
Fixes #212 

In the first commit I've added a failing test for the issue and I've left in the commit with the debug logs, if you want to test it out yourself.

Here is what the log looks like:
![Screenshot from 2020-10-29 13-54-45](https://user-images.githubusercontent.com/710155/97597283-54d45d00-1a0e-11eb-8665-7afe1df24395.png)

This is the mechanism of the error:
> 1. setState is called first in #P, which queues an update (sets _updateQueued to true and queues the UPDATE phase)
> 2. setState is then called in #C, which queues an update (sets _updateQueued to true and queues the UPDATE phase)
> 3. #P scheduler handles the UPDATE phase - runs #P's render function, queues the COMMIT phase, then sets _updateQueued to false
> 4. #C scheduler handles the UPDATE phase - runs #C's render function, queues the COMMIT phase, then sets _updateQueued to false. At this point the effect hook is called the first time. (lastValues = undefined, values = [1])
> 5. #P scheduler handles the COMMIT phase - renders the lit result, which queues a new update in #C (because _updateQueued is false) and queues the EFFECT phase
> 6. #C scheduler handles the COMMIT phase - renders the lit result with the correct values and queues the EFFECT phase
> 7. #C scheduler handles the UPDATE phase (the one queued by step 5) - runs #C's render function and queues the COMMIT phase. At this point the effect hook is called the second time, but with the same value. (lastValues = [1], values = [1])
> 8. #P scheduler handles the EFFECT phase (from step 5)
> 9. #C scheduler handles the EFFECT phase (from step 6) - the effect erroneously thinks that the dependency array has not changed, causing it to skip the effect
> 10. #C scheduler handles the COMMIT phase (from step 7)- renders the lit result, but nothing changes
> 11. #C scheduler handles the EFFECT phase (from step 10) - the effect is still skipped

My proposed fix is to update the effect's `lastValues` only *after* the effect has run, no matter how many times it is updated before it is ran. I think that this makes sense and maintains the semantics of `lastValues` as the last values for which this effect has ran.

If you have any suggestions how to improve the code or an alternative fix, please advise. 