### PR TITLE
Clarify that ContextDetail.unsubscribe property may not exist

### DIFF
--- a/src/create-context.ts
+++ b/src/create-context.ts
@@ -20,8 +20,9 @@ interface ContextDetail<T> {
   Context: Context<T>;
   callback: (value: T) => void;
 
+  // These properties will not exist if a context consumer lacks a provider
   value: T;
-  unsubscribe: (this: Context<T>) => void;
+  unsubscribe?: (this: Context<T>) => void;
 }
 
 function makeContext(component: ComponentCreator): Creator {

--- a/src/use-context.ts
+++ b/src/use-context.ts
@@ -55,7 +55,7 @@ const useContext = hook(class<T> extends Hook<[Context<T>], T, Element> {
       composed: true, // to pass ShadowDOM boundaries
     }));
 
-    const { unsubscribe, value } = detail as ContextDetail<T>;
+    const { unsubscribe = null, value } = detail as ContextDetail<T>;
 
     this.value = unsubscribe ? value : Context.defaultValue;
 


### PR DESCRIPTION
Fixes Typescript compilation error due to unsubscribe property not existing on ContextDetail when a context consumer is used without a provider.

This Typescript error is referenced in #201 and #209.