### PR TITLE
Only schedule update if prop value has changed

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -85,6 +85,7 @@ function makeComponent(render: RenderFunction): Creator {
 
     function reflectiveProp<T>(initialValue: T): Readonly<PropertyDescriptor> {
       let value = initialValue;
+      let isSetup = false;
       return Object.freeze({
         enumerable: true,
         configurable: true,
@@ -92,6 +93,9 @@ function makeComponent(render: RenderFunction): Creator {
           return value;
         },
         set(this: Element, newValue: T): void {
+          // Avoid scheduling update when prop value hasn't changed
+          if (isSetup && value === newValue) return;
+          isSetup = true;
           value = newValue;
           this._scheduler.update();
         }

--- a/src/create-context.ts
+++ b/src/create-context.ts
@@ -20,8 +20,9 @@ interface ContextDetail<T> {
   Context: Context<T>;
   callback: (value: T) => void;
 
+  // These properties will not exist if a context consumer lacks a provider
   value: T;
-  unsubscribe: (this: Context<T>) => void;
+  unsubscribe?: (this: Context<T>) => void;
 }
 
 function makeContext(component: ComponentCreator): Creator {

--- a/src/use-context.ts
+++ b/src/use-context.ts
@@ -55,7 +55,7 @@ const useContext = hook(class<T> extends Hook<[Context<T>], T, Element> {
       composed: true, // to pass ShadowDOM boundaries
     }));
 
-    const { unsubscribe, value } = detail as ContextDetail<T>;
+    const { unsubscribe = null, value } = detail as ContextDetail<T>;
 
     this.value = unsubscribe ? value : Context.defaultValue;
 

--- a/test/test-props.js
+++ b/test/test-props.js
@@ -1,5 +1,5 @@
 import { component, html } from '../haunted.js';
-import { attach, later } from './helpers.js';
+import { attach, later, cycle } from './helpers.js';
 
 describe('Passing props', () => {
   it('Are passed in the initial render', async () => {
@@ -16,7 +16,7 @@ describe('Passing props', () => {
 
     function app() {
       return html`
-        <props-first-run-test-child .prop=${{id:1}}>
+        <props-first-run-test-child .prop=${{ id: 1 }}>
         </props-first-run-test-child>
       `;
     }
@@ -24,8 +24,43 @@ describe('Passing props', () => {
 
     const teardown = attach(tag);
     await later();
-    
+
     assert.equal(runs, 1, 'child only ran once');
     teardown();
+  });
+
+  it('Only update if prop value changed', async () => {
+    const tag = 'only-update-if-prop-value-changed';
+    let runs = 0;
+
+    function app({ prop }) {
+      assert.equal(prop, 1);
+      runs++;
+      return html`testing ${prop}`;
+    }
+
+    customElements.define(tag, component(app));
+
+    const { el, teardown } = attachAndSetProp(tag, 1);
+    await cycle();
+
+    // Set prop to the exact same value. It shouldn't call app() again
+    // b/c there's no need to re-generate the template
+    el.prop = 1;
+
+    await later();
+
+    assert.equal(runs, 1, 'ran only once b/c prop did not change');
+    teardown();
+
+    function attachAndSetProp(element, propValue) {
+      let el = document.createElement(element);
+      el.prop = propValue;
+      host.appendChild(el);
+      return {
+        teardown: () => host.removeChild(el),
+        el,
+      };
+    }
   });
 });


### PR DESCRIPTION
Add a check to `reflectiveProp` that gives it similar behavior to `useState` and `attributeChangedCallback`: an update is only scheduled if the prop's value has changed.

Fixes [#192](https://github.com/matthewp/haunted/issues/192)