### PR TITLE
fix: useState updater

### DIFF
--- a/src/use-state.ts
+++ b/src/use-state.ts
@@ -29,10 +29,14 @@ const useState = hook(class<T> extends Hook {
   }
 
   updater(value: NewState<T>): void {
+    const [previousValue] = this.args;
     if (typeof value === 'function') {
       const updaterFn = value as (previousState?: T) => T;
-      const [previousValue] = this.args;
       value = updaterFn(previousValue);
+    }
+
+    if (previousValue === value) {
+      return;
     }
 
     this.makeArgs(value);


### PR DESCRIPTION
According to React's Hooks API useState updater function should trigger rerender only if state has changed.

Current behavior: updater function triggers rerender always without comparing new value with previous.