### PR TITLE
wip: upgrade to lit 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ lib/*.js: src/*.ts
 
 haunted.js: lib/*.js
 	$(COMPILE) -f es -o $@ -e lit-html lib/haunted.js
-	./sed.sh -i.bu 's/lit-html/https:\/\/unpkg\.com\/lit-html@\^1\.0\.0\/lit-html\.js/' $@
+	./sed.sh -i.bu 's/lit/https:\/\/unpkg\.com\/lit\?module/' $@
 	rm -f $@.bu
 
 web.js: haunted.js
-	./sed.sh 's/https:\/\/unpkg\.com\/lit-html@\^1\.0\.0\/lit-html\.js/\.\.\/lit-html\/lit-html\.js/' $^ > $@
+	./sed.sh 's/https:\/\/unpkg\.com\/lit\?module/\.\.\/lit\/index.js/' $^ > $@
 
 clean:
 	@rm -rf lib haunted.js web.js

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -300,7 +300,7 @@
           "name": "html",
           "declaration": {
             "name": "html",
-            "package": "https://unpkg.com/lit-html@^1.0.0/lit-html.js"
+            "package": "https://unpkg.com/lit?module"
           }
         },
         {
@@ -308,7 +308,7 @@
           "name": "render",
           "declaration": {
             "name": "render",
-            "package": "https://unpkg.com/lit-html@^1.0.0/lit-html.js"
+            "package": "https://unpkg.com/lit?module"
           }
         },
         {

--- a/docs/docs/guides/getting-started.md
+++ b/docs/docs/guides/getting-started.md
@@ -59,7 +59,7 @@ The main entry point is intended for [lit-html](https://github.com/Polymer/lit-h
 **Haunted** can work directly in the browser without using any build tools. Simply import the `haunted.js` bundle. You can use the [unpkg](https://unpkg.com/) or [pika](https://www.pika.dev/cdn) CDNs. This works great for demo pages and small apps. Here's an example with unpkg:
 
 ```js
-import { html } from 'https://unpkg.com/lit-html/lit-html.js';
+import { html } from 'https://unpkg.com/lit?module';
 import { component, useState } from 'https://unpkg.com/haunted/haunted.js';
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ callToActionItems:
 </style>
 
 ```js playground example my-counter.js
-import { html } from 'https://unpkg.com/lit-html/lit-html.js';
+import { html } from 'https://unpkg.com/lit?module';
 import { component, useState } from 'https://unpkg.com/haunted/haunted.js';
 
 function Counter() {

--- a/examples/counter.html
+++ b/examples/counter.html
@@ -3,7 +3,7 @@
 <my-counter></my-counter>
 
 <script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
+  import { html } from 'https://unpkg.com/lit?module';
   import { component, useState } from '../haunted.js';
 
   function Counter() {

--- a/examples/lit/app.js
+++ b/examples/lit/app.js
@@ -1,4 +1,4 @@
-import { html } from 'https://unpkg.com/lit-element@2.2.0/lit-element.js?module';
+import { html } from 'https://unpkg.com/lit?module';
 import { useState } from '../../haunted.js';
 import LitHauntedElement, { litHaunted } from './lit-haunted-element.js';
 
@@ -32,7 +32,7 @@ function App() {
   return html`
     <p>A paragraph</p>
     <click-element @increment=${() => setCount(count + 1)}></click-element>
-    
+
     <p><strong>Count:</strong> ${count}</p>
   `;
 }

--- a/examples/lit/lit-haunted-element.js
+++ b/examples/lit/lit-haunted-element.js
@@ -1,4 +1,4 @@
-import { LitElement } from 'https://unpkg.com/lit-element@2.2.0/lit-element.js?module';
+import { LitElement } from 'https://unpkg.com/lit?module';
 import { State } from '../../haunted.js';
 
 export default class LitHauntedElement extends LitElement {

--- a/examples/lit/make-base.js
+++ b/examples/lit/make-base.js
@@ -1,4 +1,4 @@
-import { LitElement } from 'https://unpkg.com/lit-element@2.2.0/lit-element.js?module';
+import { LitElement } from 'https://unpkg.com/lit?module';
 import { State } from '../../haunted.js';
 
 export default function(renderer) {

--- a/examples/memo.html
+++ b/examples/memo.html
@@ -3,7 +3,7 @@
 <my-app></my-app>
 
 <script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
+  import { html } from 'https://unpkg.com/lit?module';
   import { component, useMemo, useState } from '../haunted.js';
 
   function fibonacci(num) {

--- a/examples/props.html
+++ b/examples/props.html
@@ -2,7 +2,7 @@
 <my-parent></my-parent>
 
 <script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
+  import { html } from 'https://unpkg.com/lit?module';
   import { component, useState } from '../haunted.js';
 
   function MyParent() {

--- a/examples/reducer.html
+++ b/examples/reducer.html
@@ -4,7 +4,7 @@
 
 
 <script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
+  import { html } from 'https://unpkg.com/lit?module';
   import { component, useReducer } from '../haunted.js';
 
   const initialState = {count: 0};

--- a/examples/title.html
+++ b/examples/title.html
@@ -4,7 +4,7 @@
 
 
 <script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
+  import { html } from 'https://unpkg.com/lit?module';
   import { component, useState, useEffect } from '../haunted.js';
 
   function Counter() {

--- a/examples/use-controller.html
+++ b/examples/use-controller.html
@@ -3,7 +3,7 @@
 <mouse-tracker></mouse-tracker>
 
 <script type="module">
-  import { html } from 'https://unpkg.com/lit-html/lit-html.js';
+  import { html } from 'https://unpkg.com/lit?module';
   import { component, useController } from '../haunted.js';
 
   // imagine this was imported from npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,15 +5,14 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "haunted",
       "version": "4.8.2",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^1.0.0-rc.2",
-        "lit-html": "^1.0.0"
+        "lit": "^2.0.0"
       },
       "devDependencies": {
         "@custom-elements-manifest/analyzer": "^0.4.12",
-        "@lit/reactive-element": "^1.0.0-rc.1",
         "@matthewp/compile": "^3.0.0",
         "@rocket/cli": "^0.9.8",
         "@rocket/launch": "^0.5.4",
@@ -2102,9 +2101,9 @@
       }
     },
     "node_modules/@lit/reactive-element": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0-rc.2.tgz",
-      "integrity": "sha512-cujeIl5Ei8FC7UHf4/4Q3bRJOtdTe1vpJV/JEBYCggedmQ+2P8A2oz7eE+Vxi6OJ4nc0X+KZxXnBoH4QrEbmEQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0.tgz",
+      "integrity": "sha512-Kpgenb8UNFsKCsFhggiVvUkCbcFQSd6N8hffYEEGjz27/4rw3cTSsmP9t3q1EHOAsdum60Wo64HvuZDFpEwexA=="
     },
     "node_modules/@material/animation": {
       "version": "12.0.0-canary.22d29cbb4.0",
@@ -3360,10 +3359,9 @@
       }
     },
     "node_modules/@types/trusted-types": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-1.0.6.tgz",
-      "integrity": "sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==",
-      "dev": true
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
     },
     "node_modules/@types/unist": {
       "version": "2.0.5",
@@ -9868,14 +9866,13 @@
       }
     },
     "node_modules/lit": {
-      "version": "2.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.0-rc.2.tgz",
-      "integrity": "sha512-BOCuoJR04WaTV8UqTKk09cNcQA10Aq2LCcBOiHuF7TzWH5RNDsbCBP5QM9sLBSotGTXbDug/gFO08jq6TbyEtw==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.0.tgz",
+      "integrity": "sha512-pqi5O/wVzQ9Bn4ERRoYQlt1EAUWyY5Wv888vzpoArbtChc+zfUv1XohRqSdtQZYCogl0eHKd+MQwymg2XJfECg==",
       "dependencies": {
-        "@lit/reactive-element": "^1.0.0-rc.2",
-        "lit-element": "^3.0.0-rc.2",
-        "lit-html": "^2.0.0-rc.3"
+        "@lit/reactive-element": "^1.0.0",
+        "lit-element": "^3.0.0",
+        "lit-html": "^2.0.0"
       }
     },
     "node_modules/lit-element": {
@@ -9890,25 +9887,24 @@
     "node_modules/lit-html": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA=="
+      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
+      "dev": true
     },
     "node_modules/lit/node_modules/lit-element": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.0-rc.2.tgz",
-      "integrity": "sha512-2Z7DabJ3b5K+p5073vFjMODoaWqy5PIaI4y6ADKm+fCGc8OnX9fU9dMoUEBZjFpd/bEFR9PBp050tUtBnT9XTQ==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.0.tgz",
+      "integrity": "sha512-oPqRhhBBhs+AlI62QLwtWQNU/bNK/h2L1jI3IDroqZubo6XVAkyNy2dW3CRfjij8mrNlY7wULOfyyKKOnfEePA==",
       "dependencies": {
-        "@lit/reactive-element": "^1.0.0-rc.2",
-        "lit-html": "^2.0.0-rc.3"
+        "@lit/reactive-element": "^1.0.0",
+        "lit-html": "^2.0.0"
       }
     },
     "node_modules/lit/node_modules/lit-html": {
-      "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.0-rc.3.tgz",
-      "integrity": "sha512-Y6P8LlAyQuqvzq6l/Nc4z5/P5M/rVLYKQIRxcNwSuGajK0g4kbcBFQqZmgvqKG+ak+dHZjfm2HUw9TF5N/pkCw==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.0.tgz",
+      "integrity": "sha512-tJsCapCmc0vtLj6harqd6HfCxnlt/RSkgowtz4SC9dFE3nSL38Tb33I5HMDiyJsRjQZRTgpVsahrnDrR9wg27w==",
       "dependencies": {
-        "@types/trusted-types": "^1.0.1"
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/localtunnel": {
@@ -17684,9 +17680,9 @@
       }
     },
     "@lit/reactive-element": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0-rc.2.tgz",
-      "integrity": "sha512-cujeIl5Ei8FC7UHf4/4Q3bRJOtdTe1vpJV/JEBYCggedmQ+2P8A2oz7eE+Vxi6OJ4nc0X+KZxXnBoH4QrEbmEQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0.tgz",
+      "integrity": "sha512-Kpgenb8UNFsKCsFhggiVvUkCbcFQSd6N8hffYEEGjz27/4rw3cTSsmP9t3q1EHOAsdum60Wo64HvuZDFpEwexA=="
     },
     "@material/animation": {
       "version": "12.0.0-canary.22d29cbb4.0",
@@ -18860,10 +18856,9 @@
       }
     },
     "@types/trusted-types": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-1.0.6.tgz",
-      "integrity": "sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==",
-      "dev": true
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
     },
     "@types/unist": {
       "version": "2.0.5",
@@ -24161,33 +24156,30 @@
       "dev": true
     },
     "lit": {
-      "version": "2.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.0-rc.2.tgz",
-      "integrity": "sha512-BOCuoJR04WaTV8UqTKk09cNcQA10Aq2LCcBOiHuF7TzWH5RNDsbCBP5QM9sLBSotGTXbDug/gFO08jq6TbyEtw==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.0.tgz",
+      "integrity": "sha512-pqi5O/wVzQ9Bn4ERRoYQlt1EAUWyY5Wv888vzpoArbtChc+zfUv1XohRqSdtQZYCogl0eHKd+MQwymg2XJfECg==",
       "requires": {
-        "@lit/reactive-element": "^1.0.0-rc.2",
-        "lit-element": "^3.0.0-rc.2",
-        "lit-html": "^2.0.0-rc.3"
+        "@lit/reactive-element": "^1.0.0",
+        "lit-element": "^3.0.0",
+        "lit-html": "^2.0.0"
       },
       "dependencies": {
         "lit-element": {
-          "version": "3.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.0-rc.2.tgz",
-          "integrity": "sha512-2Z7DabJ3b5K+p5073vFjMODoaWqy5PIaI4y6ADKm+fCGc8OnX9fU9dMoUEBZjFpd/bEFR9PBp050tUtBnT9XTQ==",
-          "dev": true,
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.0.tgz",
+          "integrity": "sha512-oPqRhhBBhs+AlI62QLwtWQNU/bNK/h2L1jI3IDroqZubo6XVAkyNy2dW3CRfjij8mrNlY7wULOfyyKKOnfEePA==",
           "requires": {
-            "@lit/reactive-element": "^1.0.0-rc.2",
-            "lit-html": "^2.0.0-rc.3"
+            "@lit/reactive-element": "^1.0.0",
+            "lit-html": "^2.0.0"
           }
         },
         "lit-html": {
-          "version": "2.0.0-rc.3",
-          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.0-rc.3.tgz",
-          "integrity": "sha512-Y6P8LlAyQuqvzq6l/Nc4z5/P5M/rVLYKQIRxcNwSuGajK0g4kbcBFQqZmgvqKG+ak+dHZjfm2HUw9TF5N/pkCw==",
-          "dev": true,
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.0.tgz",
+          "integrity": "sha512-tJsCapCmc0vtLj6harqd6HfCxnlt/RSkgowtz4SC9dFE3nSL38Tb33I5HMDiyJsRjQZRTgpVsahrnDrR9wg27w==",
           "requires": {
-            "@types/trusted-types": "^1.0.1"
+            "@types/trusted-types": "^2.0.2"
           }
         }
       }
@@ -24204,7 +24196,8 @@
     "lit-html": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA=="
+      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
+      "dev": true
     },
     "localtunnel": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "typings": "lib/haunted.d.ts",
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.4.12",
-    "@lit/reactive-element": "^1.0.0-rc.1",
     "@matthewp/compile": "^3.0.0",
     "@rocket/cli": "^0.9.8",
     "@rocket/launch": "^0.5.4",
@@ -50,7 +49,6 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@lit/reactive-element": "^1.0.0-rc.2",
-    "lit-html": "^1.0.0"
+    "lit": "^2.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ React's Hooks API but for standard web components and [lit-html](https://lit-htm
   <my-counter></my-counter>
 
   <script type="module">
-    import { html } from 'https://unpkg.com/lit-html/lit-html.js';
+    import { html } from 'https://unpkg.com/lit?module';
     import { component, useState } from 'https://unpkg.com/haunted/haunted.js';
 
     function Counter() {

--- a/src/lit-haunted.ts
+++ b/src/lit-haunted.ts
@@ -1,4 +1,4 @@
-import { html, render } from 'lit-html';
+import { html, render } from 'lit';
 import haunted from './core';
 import { makeVirtual } from './virtual';
 

--- a/src/virtual.ts
+++ b/src/virtual.ts
@@ -1,4 +1,4 @@
-import { directive, NodePart } from 'lit-html';
+import { Directive, directive, DirectiveParameters, NodePart, Part } from 'lit/directive.js';
 import { GenericRenderer } from './core';
 import { BaseScheduler } from './scheduler';
 
@@ -37,21 +37,25 @@ function makeVirtual() {
   }
 
   function virtual(renderer: Renderer) {
-    function factory(...args: unknown[]) {
-      return (part: NodePart): void => {
-        let cont = partToScheduler.get(part);
-        if(!cont) {
-          cont = new Scheduler(renderer, part);
-          partToScheduler.set(part, cont);
-          schedulerToPart.set(cont, part);
-          teardownOnRemove(cont, part);
-        }
-        cont.args = args;
-        cont.update();
-      };
+    class VirtualDirective extends Directive {
+
+      update(part: Part, args: DirectiveParameters<this>) {
+          let cont = partToScheduler.get(part);
+          if(!cont) {
+            cont = new Scheduler(renderer, part);
+            partToScheduler.set(part, cont);
+            schedulerToPart.set(cont, part);
+            teardownOnRemove(cont, part);
+          }
+          cont.args = args;
+          cont.update();
+          this.render(...args);
+      }
+      render(...args: unknown[]) {
+      }
     }
 
-    return directive(factory);
+    return directive(VirtualDirective);
   }
 
   return virtual;

--- a/test/debug/virtual-teardown.html
+++ b/test/debug/virtual-teardown.html
@@ -9,7 +9,7 @@
   <body>
     <counter-app></counter-app>
     <script type="module">
-import { html, render } from "https://unpkg.com/lit-html/lit-html.js";
+import { html, render } from "https://unpkg.com/lit?module";
 import {
   component,
   useEffect,


### PR DESCRIPTION
## What I Did
- replace references to lit-html and lit-html with lit
- update unpkg urls
- update makefile
- cursory attempt at upgrading virtual directive

## For Reviewers
I'm not so familiar with how the virtual directive works under the hood, and it wasn't immediately obvious how to update it, so it seems virtual.ts needs some considerable thought in order to upgrade.

NB: deploy preview docs site remains broken because it loads haunted from unpkg, not from source.

## Linked Issues
Fixes #306 