### PR TITLE
feat(create-context): don't use Shadow Root.

### DIFF
--- a/.changeset/polite-crabs-admire.md
+++ b/.changeset/polite-crabs-admire.md
@@ -1,0 +1,5 @@
+---
+"haunted": patch
+---
+
+Don't use Shadow Root for contexts.

--- a/src/create-context.ts
+++ b/src/create-context.ts
@@ -76,7 +76,7 @@ function makeContext(component: ComponentCreator): Creator {
         const context = useContext(Context);
 
         return render(context);
-      }),
+      }, { useShadowDOM: false }),
 
       defaultValue,
     };

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -93,7 +93,7 @@ describe('context', function() {
   }
 
   function getContentResults(selector: string) {
-    return [...document.querySelector('context-tests').shadowRoot.querySelectorAll(selector)].map((consumer) => (consumer).shadowRoot.textContent);
+    return [...document.querySelector('context-tests').shadowRoot.querySelectorAll(selector)].map((consumer) => (consumer).textContent);
   }
 
   beforeEach(async () => {


### PR DESCRIPTION
The Context's Consumer component does not need to have a ShadowRoot because it would be very hard to style elements inside it. (part)

fixes #384