### PR TITLE
fix: set test concurrency to 1 to prevent flaky timeouts

### DIFF
--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -4,6 +4,7 @@ export default {
   nodeResolve: true,
   plugins: [esbuildPlugin({ ts: true })],
   files: ["**!(node_modules)/*.test.(j|t)s"],
+  concurrency: 1,
   testFramework: {
     config: {
       timeout: "5000",


### PR DESCRIPTION
## Summary

- Fix 20 out of 54 tests failing with 5-second timeouts by setting `concurrency: 1` in `web-test-runner.config.mjs`
- The default concurrency runs multiple test files in parallel browser pages against a single Chrome instance, overwhelming microtask-based scheduling (`Promise.resolve().then`) and `nextFrame()` timing that the haunted scheduler relies on
- Tests affected span `useEffect`, `useState`, `useRef`, `useLayoutEffect`, `virtual()`, and attribute observation — all relying on async re-render cycles that become unreliable under concurrent browser load

## Root Cause

`@web/test-runner` defaults to running test files concurrently across multiple browser pages. The haunted scheduler in `src/scheduler.ts` uses microtask-based batching (`Promise.resolve().then`) to coordinate read/write/effects phases. When many browser pages compete for the same Chrome process, these microtasks and `requestAnimationFrame`-based `nextFrame()` calls in tests don't resolve within the 5-second Mocha timeout.

Evidence:
| Concurrency | Result |
|---|---|
| Default (CPU cores) | 20 failures, 43s |
| 2 | 6 failures, 32s |
| **1** | **0 failures, 3.5s** |

## Changes

Single-line addition to `web-test-runner.config.mjs`:

```js
concurrency: 1,
```